### PR TITLE
Fix missing getToken parameter in OrganizationRegisterActions calls

### DIFF
--- a/src/actions/OrganizationRegisterActions.js
+++ b/src/actions/OrganizationRegisterActions.js
@@ -627,7 +627,7 @@ OrganizationRegisterActions.getUserNotifications = (
   }
 
   if (!organizations.length) {
-    dispatch(OrganizationRegisterActions.getOrganizations());
+    dispatch(OrganizationRegisterActions.getOrganizations(getToken));
   }
 
   if (!administrativeZones.length) {
@@ -639,7 +639,7 @@ OrganizationRegisterActions.getUserNotifications = (
   }
 
   if (!entityTypes.length) {
-    dispatch(OrganizationRegisterActions.getEntityTypes());
+    dispatch(OrganizationRegisterActions.getEntityTypes(getToken));
   }
 
   return axios

--- a/src/modals/ModalEditNotifications.jsx
+++ b/src/modals/ModalEditNotifications.jsx
@@ -35,8 +35,10 @@ class ModalEditNotifications extends React.Component {
   }
 
   componentDidMount() {
-    const { user, dispatch } = this.props;
-    dispatch(OrganizationRegisterActions.getUserNotifications(user.username));
+    const { user, dispatch, getToken } = this.props;
+    dispatch(
+      OrganizationRegisterActions.getUserNotifications(user.username, getToken)
+    );
   }
 
   handleExpandItem(index, value) {
@@ -46,9 +48,12 @@ class ModalEditNotifications extends React.Component {
   }
 
   async handleUpdate() {
-    const { user, dispatch } = this.props;
+    const { user, dispatch, getToken } = this.props;
     await dispatch(
-      OrganizationRegisterActions.updateUserNotification(user.username)
+      OrganizationRegisterActions.updateUserNotification(
+        user.username,
+        getToken
+      )
     );
     this.props.handleCloseModal();
   }

--- a/src/screens/providers/components/entityTypesView/EntityTypesView.jsx
+++ b/src/screens/providers/components/entityTypesView/EntityTypesView.jsx
@@ -87,21 +87,24 @@ class EntityTypesView extends React.Component {
   }
 
   handleCreateEntity(entityType) {
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.createEntityType(entityType)
+      OrganizationRegisterActions.createEntityType(entityType, getToken)
     );
   }
 
   handleUpdateEntity(entityType) {
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.updateEntityType(entityType)
+      OrganizationRegisterActions.updateEntityType(entityType, getToken)
     );
   }
 
   handleDeleteEntityType(entityType) {
     this.handleCloseDeleteConfirmation();
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.deleteEntityType(entityType.id)
+      OrganizationRegisterActions.deleteEntityType(entityType.id, getToken)
     );
   }
 

--- a/src/screens/providers/components/organizationView/OrganizationView.jsx
+++ b/src/screens/providers/components/organizationView/OrganizationView.jsx
@@ -85,14 +85,16 @@ class OrganizationView extends React.Component {
   }
 
   handleCreateOrganization(organization) {
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.createOrganization(organization)
+      OrganizationRegisterActions.createOrganization(organization, getToken)
     );
   }
 
   handleUpdateOrganization(organization) {
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.updateOrganization(organization)
+      OrganizationRegisterActions.updateOrganization(organization, getToken)
     );
   }
 
@@ -105,8 +107,9 @@ class OrganizationView extends React.Component {
 
   handleDeleteOrganization(organization) {
     this.handleCloseDeleteConfirmation();
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.deleteOrganization(organization.id)
+      OrganizationRegisterActions.deleteOrganization(organization.id, getToken)
     );
   }
 

--- a/src/screens/providers/components/responsibilitiesView/ResponsibilitiesView.jsx
+++ b/src/screens/providers/components/responsibilitiesView/ResponsibilitiesView.jsx
@@ -124,21 +124,33 @@ class ResponsibilitiesView extends React.Component {
   }
 
   handleCreateResponsibilitySet(responsibilitySet) {
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.createResponsibilitySet(responsibilitySet)
+      OrganizationRegisterActions.createResponsibilitySet(
+        responsibilitySet,
+        getToken
+      )
     );
   }
 
   handleUpdateResponsibilitySet(responsibilitySet) {
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.updateResponsibilitySet(responsibilitySet)
+      OrganizationRegisterActions.updateResponsibilitySet(
+        responsibilitySet,
+        getToken
+      )
     );
   }
 
   handleDeleteResponsibility(responsibility) {
     this.handleCloseDeleteConfirmation();
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.deleteResponsibilitySet(responsibility.id)
+      OrganizationRegisterActions.deleteResponsibilitySet(
+        responsibility.id,
+        getToken
+      )
     );
   }
 

--- a/src/screens/providers/components/roleView/RoleView.jsx
+++ b/src/screens/providers/components/roleView/RoleView.jsx
@@ -92,11 +92,13 @@ class RoleView extends React.Component {
   }
 
   handleCreateRole(role) {
-    this.props.dispatch(OrganizationRegisterActions.createRole(role));
+    const { getToken } = this.props;
+    this.props.dispatch(OrganizationRegisterActions.createRole(role, getToken));
   }
 
   handleUpdateRole(role) {
-    this.props.dispatch(OrganizationRegisterActions.updateRole(role));
+    const { getToken } = this.props;
+    this.props.dispatch(OrganizationRegisterActions.updateRole(role, getToken));
     this.setState({
       isEditModalOpen: false
     });
@@ -104,7 +106,10 @@ class RoleView extends React.Component {
 
   handleDeleteRole(role) {
     this.handleCloseDeleteConfirmation();
-    this.props.dispatch(OrganizationRegisterActions.deleteRole(role.id));
+    const { getToken } = this.props;
+    this.props.dispatch(
+      OrganizationRegisterActions.deleteRole(role.id, getToken)
+    );
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/screens/providers/components/userView/UserView.jsx
+++ b/src/screens/providers/components/userView/UserView.jsx
@@ -62,21 +62,31 @@ class UserView extends React.Component {
   }
 
   handleCreateUser(user) {
-    this.props.dispatch(OrganizationRegisterActions.createUser(user));
+    const { getToken } = this.props;
+    this.props.dispatch(OrganizationRegisterActions.createUser(user, getToken));
   }
 
   handleUpdateUser(user) {
-    this.props.dispatch(OrganizationRegisterActions.updateUser(user));
+    const { getToken } = this.props;
+    this.props.dispatch(OrganizationRegisterActions.updateUser(user, getToken));
   }
 
   handleDeleteUser(user) {
     this.handleCloseDeleteConfirmation();
-    this.props.dispatch(OrganizationRegisterActions.deleteUser(user.id));
+    const { getToken } = this.props;
+    this.props.dispatch(
+      OrganizationRegisterActions.deleteUser(user.id, getToken)
+    );
   }
 
   handleResetPassword(user) {
+    const { getToken } = this.props;
     this.props.dispatch(
-      OrganizationRegisterActions.resetPassword(user.id, user.username)
+      OrganizationRegisterActions.resetPassword(
+        user.id,
+        user.username,
+        getToken
+      )
     );
     this.handleCloseResetConfirmation();
   }
@@ -370,6 +380,7 @@ class UserView extends React.Component {
               }
               isModalOpen={isNotificationsOpen}
               user={this.state.activeUser}
+              getToken={this.props.getToken}
             />
           )}
           <ModalConfirmation


### PR DESCRIPTION
Fixed TypeError where getToken was not being passed to functions that require authentication. Updated all calls to OrganizationRegisterActions functions to include the getToken parameter when making API requests through getApiConfig.