### PR TITLE
Local dev: use real JWT from mock-oauth2

### DIFF
--- a/src/app/Router.jsx
+++ b/src/app/Router.jsx
@@ -9,7 +9,6 @@ import { useAuth } from '../auth';
 import { connect } from 'react-redux';
 import SuppliersActions from 'actions/SuppliersActions';
 import { MicroFrontendFetchStatus } from './components/MicroFrontendFetchStatus';
-import { getProvidersEnv } from 'config/themes';
 
 const notifyNetexValidationReportLoadingFailure = dispatch => () => {
   dispatch(
@@ -44,7 +43,7 @@ const Router = ({ dispatch }) => {
               payload={{
                 getToken,
                 locale: 'en',
-                env: getProvidersEnv(window.config.providersBaseUrl).toLocaleLowerCase(),
+                env: window.config.appEnv,
               }}
               FetchStatus={props => (
                 <MicroFrontendFetchStatus

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -4,18 +4,14 @@ import { useAuth as useOidcAuth } from 'react-oidc-context';
 
 let localDevAccessToken: string | undefined;
 
-export const fetchAndCacheLocalDevToken = async (
-  tokenUrl: string
-): Promise<void> => {
+export const fetchAndCacheLocalDevToken = async (tokenUrl: string): Promise<void> => {
   const response = await fetch(tokenUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: 'grant_type=client_credentials&client_id=ninkasi&client_secret=notUsed',
   });
   if (!response.ok) {
-    throw new Error(
-      `Failed to fetch local dev token: ${response.status} ${response.statusText}`
-    );
+    throw new Error(`Failed to fetch local dev token: ${response.status} ${response.statusText}`);
   }
   const data = await response.json();
   localDevAccessToken = data.access_token;

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -2,11 +2,32 @@ export { AuthProvider } from './AuthProvider';
 
 import { useAuth as useOidcAuth } from 'react-oidc-context';
 
+let localDevAccessToken: string | undefined;
+
+export const fetchAndCacheLocalDevToken = async (
+  tokenUrl: string
+): Promise<void> => {
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'grant_type=client_credentials&client_id=ninkasi&client_secret=notUsed',
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch local dev token: ${response.status} ${response.statusText}`
+    );
+  }
+  const data = await response.json();
+  localDevAccessToken = data.access_token;
+};
+
 const localAuth = {
   isAuthenticated: true,
   isLoading: false,
   user: {
-    access_token: 'local-dev-token',
+    get access_token() {
+      return localDevAccessToken;
+    },
     token_type: 'Bearer',
     profile: {
       sub: 'local-dev',

--- a/src/config/environments/local.json
+++ b/src/config/environments/local.json
@@ -12,10 +12,11 @@
   "endpointBase": "/",
   "chouetteBaseUrl": "http://localhost:21080/",
   "udugBaseUrl": "/netex-validation-reports/",
-  "udugMicroFrontendUrl": "",
+  "udugMicroFrontendUrl": "http://localhost:21002",
   "ninsarBaseUrl": "/line-statistics/",
   "ninsarMicroFrontendUrl": "",
   "zagmukMicroFrontendUrl": "http://localhost:21001",
   "enturPartnerUrl": "",
-  "defaultAuthMethod": "local"
+  "defaultAuthMethod": "local",
+  "mockOauth2TokenUrl": "http://localhost:21999/default/token"
 }

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -12,6 +12,7 @@ export interface Config {
   mapboxAdminBaseUrl?: string;
   enableGoogleTasks?: boolean;
   defaultAuthMethod?: string;
+  mockOauth2TokenUrl?: string;
   netexPrefix?: string;
   uttuBaseUrl?: string;
   organisationRegisterBaseUrl?: string;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,15 +8,23 @@ import App from './app/App';
 import configureStore from './store/store';
 import { fetchConfig } from './config/fetchConfig';
 import { ConfigContext } from './contexts/ConfigContext';
-import { AuthProvider } from './auth';
+import { AuthProvider, fetchAndCacheLocalDevToken } from './auth';
 
 // Initialize micro-frontend route change emitter
 startRouteChangeEmitter();
 
 // Fetch config and render app
-fetchConfig().then(config => {
+fetchConfig().then(async config => {
   // Store config globally for legacy code compatibility
   (window as any).config = config;
+
+  if (config.defaultAuthMethod === 'local' && config.mockOauth2TokenUrl) {
+    try {
+      await fetchAndCacheLocalDevToken(config.mockOauth2TokenUrl);
+    } catch (err) {
+      console.error('Failed to fetch local dev token from mock-oauth2:', err);
+    }
+  }
 
   createRoot(document.getElementById('root')!).render(
     <StrictMode>


### PR DESCRIPTION
fetch a real JWT from mock-oauth2 at startup and use it instead of a placeholder; point local config at the udug micro-frontend and mock-oauth2 token endpoint; pass appEnv to udug so it loads local.json on localhost.