### PR TITLE
PR-B: reducers → createSlice

### DIFF
--- a/src/reducers/AppReducer.js
+++ b/src/reducers/AppReducer.js
@@ -14,22 +14,22 @@
  *
  */
 
+import { createSlice } from '@reduxjs/toolkit';
 import * as types from 'actions/actionTypes';
 
-const intialState = {
+const initialState = {
   isMenuOpen: false,
 };
 
-const AppReducer = (state = intialState, action) => {
-  switch (action.type) {
-    case types.TOGGLE_MENU:
-      return Object.assign({}, state, {
-        isMenuOpen: !state.isMenuOpen,
-      });
+const appSlice = createSlice({
+  name: 'app',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(types.TOGGLE_MENU, state => {
+      state.isMenuOpen = !state.isMenuOpen;
+    });
+  },
+});
 
-    default:
-      return state;
-  }
-};
-
-export default AppReducer;
+export default appSlice.reducer;

--- a/src/reducers/MardukReducer.js
+++ b/src/reducers/MardukReducer.js
@@ -14,9 +14,10 @@
  *
  */
 
+import { createSlice } from '@reduxjs/toolkit';
 import * as types from 'actions/actionTypes';
 
-const cleanSlate = {
+const initialState = {
   filenames: {
     isLoading: false,
   },
@@ -46,253 +47,141 @@ const cleanSlate = {
   requesting_chouette_all_job: false,
 };
 
-const MardukReducer = (state = cleanSlate, action) => {
-  switch (action.type) {
-    case types.ERROR_IMPORT_DATA:
-      return Object.assign({}, state, {
-        isLoading: false,
-        import_data: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_IMPORT_DATA:
-      return Object.assign({}, state, {
-        isLoading: false,
-        import_data: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_IMPORT_DATA:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_EXPORT_DATA:
-      return Object.assign({}, state, {
-        isLoading: false,
-        export_data: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_EXPORT_DATA:
-      return Object.assign({}, state, {
-        isLoading: false,
-        export_data: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_EXPORT_DATA:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_TRANSFER_DATA:
-      return Object.assign({}, state, {
-        isLoading: false,
-        transfer_data: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_TRANSFER_DATA:
-      return Object.assign({}, state, {
-        isLoading: false,
-        transfer_data: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_TRANSFER_DATA:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_DELETE_DATA:
-      return Object.assign({}, state, {
-        isLoading: false,
-        delete_data: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_DELETE_DATA:
-      return Object.assign({}, state, {
-        isLoading: false,
-        delete_data: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_DELETE_DATA:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_BUILD_GRAPH:
-      return Object.assign({}, state, {
-        isLoading: false,
-        build_graph: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_BUILD_GRAPH:
-      return Object.assign({}, state, {
-        isLoading: false,
-        build_graph: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_BUILD_GRAPH:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_BUILD_BASE_GRAPH:
-      return Object.assign({}, state, {
-        isLoading: false,
-        build_base_graph: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_BUILD_BASE_GRAPH:
-      return Object.assign({}, state, {
-        isLoading: false,
-        build_base_graph: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_BUILD_BASE_GRAPH:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_BUILD_CANDIDATE_GRAPH_OTP:
-      return Object.assign({}, state, {
-        isLoading: false,
-        build_candidate_graph_otp: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_BUILD_CANDIDATE_GRAPH_OTP:
-      return Object.assign({}, state, {
-        isLoading: false,
-        build_candidate_graph_otp: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_BUILD_CANDIDATE_GRAPH_OTP:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_BUILD_CANDIDATE_BASE_GRAPH_OTP:
-      return Object.assign({}, state, {
-        isLoading: false,
-        build_candidate_base_graph_otp: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_BUILD_CANDIDATE_BASE_GRAPH_OTP:
-      return Object.assign({}, state, {
-        isLoading: false,
-        build_candidate_base_graph_otp: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_BUILD_CANDIDATE_BASE_GRAPH_OTP:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_FETCH_OSM:
-      return Object.assign({}, state, {
-        isLoading: false,
-        fetch_osm: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_FETCH_OSM:
-      return Object.assign({}, state, {
-        isLoading: false,
-        fetch_osm: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_FETCH_OSM:
-      return Object.assign({}, state, { isLoading: true, error: false });
-
-    case types.ERROR_VALIDATE_PROVIDER:
-      return Object.assign({}, state, {
-        isLoading: false,
-        validate_provider: action.payLoad,
-        error: true,
-      });
-
-    case types.SUCCESS_VALIDATE_PROVIDER:
-      return Object.assign({}, state, {
-        isLoading: false,
-        validate_provider: action.payLoad,
-        error: false,
-      });
-
-    case types.REQUEST_FILENAMES:
-      return Object.assign({}, state, {
-        filenames: { isLoading: true, error: false },
-      });
-
-    case types.SUCCESS_FILENAMES:
-      return Object.assign({}, state, {
-        filenames: { isLoading: false, data: action.payLoad, error: false },
-      });
-
-    case types.ERROR_FILENAMES:
-      return Object.assign({}, state, {
-        filesnames: { isLoading: false, error: action.payLoad },
-      });
-
-    case types.SUCCESS_CHOUETTE_JOB_STATUS:
-      return Object.assign({}, state, {
-        requesting_chouette_job: false,
-        chouetteJobStatus: action.payLoad,
-      });
-
-    case types.SUCCESS_ALL_CHOUETTE_JOB_STATUS:
-      return Object.assign({}, state, {
-        requesting_chouette_all_job: false,
-        chouetteAllJobStatus: action.payLoad,
-      });
-
-    case types.TOGGLE_CHOUETTE_INFO_CHECKBOX_FILTER: {
-      const chouetteJobFilter = { ...state.chouetteJobFilter };
-      chouetteJobFilter[action.payLoad.option] = action.payLoad.value;
-      return Object.assign({}, state, { chouetteJobFilter: chouetteJobFilter });
-    }
-
-    case types.TOGGLE_CHOUETTE_INFO_CHECKBOX_ALL_FILTER: {
-      const chouetteJobAllFilter = { ...state.chouetteJobAllFilter };
-      chouetteJobAllFilter[action.payLoad.option] = action.payLoad.value;
-      return Object.assign({}, state, {
-        chouetteJobAllFilter: chouetteJobAllFilter,
-      });
-    }
-
-    case types.SET_ACTIVE_ACTION_FILTER:
-      return Object.assign({}, state, { actionFilter: action.payLoad });
-
-    case types.SET_ACTIVE_ACTION_ALL_FILTER:
-      return Object.assign({}, state, { actionAllFilter: action.payLoad });
-
-    case types.REQUESTED_CHOUETTE_JOBS_FOR_PROVIDER:
-      if (state.chouette_cancel_token) {
-        const cancelToken = state.chouette_cancel_token;
-        cancelToken('Operation canceled by new request.');
-      }
-
-      return Object.assign({}, state, {
-        requesting_chouette_job: true,
-        chouette_cancel_token: action.payLoad,
-      });
-
-    case types.REQUESTED_ALL_CHOUETTE_JOB_STATUS:
-      if (state.chouette_cancel_all_token) {
-        const cancelAllToken = state.chouette_cancel_all_token;
-        cancelAllToken('Operation canceled by new request');
-      }
-
-      return Object.assign({}, state, {
-        requesting_chouette_all_job: true,
-        chouette_cancel_all_token: action.payLoad,
-      });
-
-    case types.SELECTED_ALL_SUPPLIERS:
-      return Object.assign({}, state, {
-        chouette_cancel_all_token: null,
-        chouette_cancel_token: null,
-      });
-
-    default:
-      return state;
-  }
+const setOpData = (state, key, payLoad, errored) => {
+  state.isLoading = false;
+  state[key] = payLoad;
+  state.error = errored;
 };
 
-export default MardukReducer;
+const setRequesting = state => {
+  state.isLoading = true;
+  state.error = false;
+};
+
+const mardukSlice = createSlice({
+  name: 'marduk',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(types.ERROR_IMPORT_DATA, (state, action) =>
+        setOpData(state, 'import_data', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_IMPORT_DATA, (state, action) =>
+        setOpData(state, 'import_data', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_IMPORT_DATA, setRequesting)
+      .addCase(types.ERROR_EXPORT_DATA, (state, action) =>
+        setOpData(state, 'export_data', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_EXPORT_DATA, (state, action) =>
+        setOpData(state, 'export_data', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_EXPORT_DATA, setRequesting)
+      .addCase(types.ERROR_TRANSFER_DATA, (state, action) =>
+        setOpData(state, 'transfer_data', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_TRANSFER_DATA, (state, action) =>
+        setOpData(state, 'transfer_data', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_TRANSFER_DATA, setRequesting)
+      .addCase(types.ERROR_DELETE_DATA, (state, action) =>
+        setOpData(state, 'delete_data', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_DELETE_DATA, (state, action) =>
+        setOpData(state, 'delete_data', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_DELETE_DATA, setRequesting)
+      .addCase(types.ERROR_BUILD_GRAPH, (state, action) =>
+        setOpData(state, 'build_graph', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_BUILD_GRAPH, (state, action) =>
+        setOpData(state, 'build_graph', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_BUILD_GRAPH, setRequesting)
+      .addCase(types.ERROR_BUILD_BASE_GRAPH, (state, action) =>
+        setOpData(state, 'build_base_graph', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_BUILD_BASE_GRAPH, (state, action) =>
+        setOpData(state, 'build_base_graph', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_BUILD_BASE_GRAPH, setRequesting)
+      .addCase(types.ERROR_BUILD_CANDIDATE_GRAPH_OTP, (state, action) =>
+        setOpData(state, 'build_candidate_graph_otp', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_BUILD_CANDIDATE_GRAPH_OTP, (state, action) =>
+        setOpData(state, 'build_candidate_graph_otp', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_BUILD_CANDIDATE_GRAPH_OTP, setRequesting)
+      .addCase(types.ERROR_BUILD_CANDIDATE_BASE_GRAPH_OTP, (state, action) =>
+        setOpData(state, 'build_candidate_base_graph_otp', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_BUILD_CANDIDATE_BASE_GRAPH_OTP, (state, action) =>
+        setOpData(state, 'build_candidate_base_graph_otp', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_BUILD_CANDIDATE_BASE_GRAPH_OTP, setRequesting)
+      .addCase(types.ERROR_FETCH_OSM, (state, action) =>
+        setOpData(state, 'fetch_osm', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_FETCH_OSM, (state, action) =>
+        setOpData(state, 'fetch_osm', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_FETCH_OSM, setRequesting)
+      .addCase(types.ERROR_VALIDATE_PROVIDER, (state, action) =>
+        setOpData(state, 'validate_provider', action.payLoad, true)
+      )
+      .addCase(types.SUCCESS_VALIDATE_PROVIDER, (state, action) =>
+        setOpData(state, 'validate_provider', action.payLoad, false)
+      )
+      .addCase(types.REQUEST_FILENAMES, state => {
+        state.filenames = { isLoading: true, error: false };
+      })
+      .addCase(types.SUCCESS_FILENAMES, (state, action) => {
+        state.filenames = { isLoading: false, data: action.payLoad, error: false };
+      })
+      .addCase(types.ERROR_FILENAMES, (state, action) => {
+        // NOTE: typo `filesnames` preserved from original behavior.
+        state.filesnames = { isLoading: false, error: action.payLoad };
+      })
+      .addCase(types.SUCCESS_CHOUETTE_JOB_STATUS, (state, action) => {
+        state.requesting_chouette_job = false;
+        state.chouetteJobStatus = action.payLoad;
+      })
+      .addCase(types.SUCCESS_ALL_CHOUETTE_JOB_STATUS, (state, action) => {
+        state.requesting_chouette_all_job = false;
+        state.chouetteAllJobStatus = action.payLoad;
+      })
+      .addCase(types.TOGGLE_CHOUETTE_INFO_CHECKBOX_FILTER, (state, action) => {
+        state.chouetteJobFilter[action.payLoad.option] = action.payLoad.value;
+      })
+      .addCase(types.TOGGLE_CHOUETTE_INFO_CHECKBOX_ALL_FILTER, (state, action) => {
+        state.chouetteJobAllFilter[action.payLoad.option] = action.payLoad.value;
+      })
+      .addCase(types.SET_ACTIVE_ACTION_FILTER, (state, action) => {
+        state.actionFilter = action.payLoad;
+      })
+      .addCase(types.SET_ACTIVE_ACTION_ALL_FILTER, (state, action) => {
+        state.actionAllFilter = action.payLoad;
+      })
+      .addCase(types.REQUESTED_CHOUETTE_JOBS_FOR_PROVIDER, (state, action) => {
+        if (state.chouette_cancel_token) {
+          state.chouette_cancel_token('Operation canceled by new request.');
+        }
+        state.requesting_chouette_job = true;
+        state.chouette_cancel_token = action.payLoad;
+      })
+      .addCase(types.REQUESTED_ALL_CHOUETTE_JOB_STATUS, (state, action) => {
+        if (state.chouette_cancel_all_token) {
+          state.chouette_cancel_all_token('Operation canceled by new request');
+        }
+        state.requesting_chouette_all_job = true;
+        state.chouette_cancel_all_token = action.payLoad;
+      })
+      .addCase(types.SELECTED_ALL_SUPPLIERS, state => {
+        state.chouette_cancel_all_token = null;
+        state.chouette_cancel_token = null;
+      });
+  },
+});
+
+export default mardukSlice.reducer;

--- a/src/reducers/OrganizationReducer.js
+++ b/src/reducers/OrganizationReducer.js
@@ -14,6 +14,7 @@
  *
  */
 
+import { createSlice } from '@reduxjs/toolkit';
 import * as types from 'actions/actionTypes';
 import {
   changeFilterValue,
@@ -45,300 +46,184 @@ const initialState = {
   m2mClientStatus: { error: null },
 };
 
-const removeByIndex = (list, index) => [...list.slice(0, index), ...list.slice(index + 1)];
+const setStatus = (state, key, code, error = null) => {
+  state[key] = { error, code };
+};
 
-const OrganizationReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case types.RECEIVED_ROLES:
-      return Object.assign({}, state, { roles: action.payLoad });
-
-    case types.CREATED_ROLE:
-      return Object.assign({}, state, {
-        roleStatus: {
-          error: null,
-          code: 'ROLE_CREATED',
-        },
-      });
-
-    case types.FAILED_CREATING_ROLE:
-      return Object.assign({}, state, {
-        roleStatus: {
-          error: action.payLoad,
-          code: 'ROLE_CREATED_FAILED',
-        },
-      });
-
-    case types.RECEIVED_ORGANIZATIONS:
-      return Object.assign({}, state, { organizations: action.payLoad });
-
-    case types.CREATED_ORGANIZATION:
-      return Object.assign({}, state, {
-        organizationStatus: {
-          error: null,
-          code: 'ORGANIZATION_CREATED',
-        },
-      });
-
-    case types.UPDATED_ORGANIZATION:
-      return Object.assign({}, state, {
-        organizationStatus: {
-          error: null,
-          code: 'ORGANIZATION_UPDATED',
-        },
-      });
-
-    case types.FAILED_CREATING_ORGANIZATION:
-      return Object.assign({}, state, {
-        organizationStatus: {
-          error: action.payLoad,
-          code: 'ORGANIZATION_CREATED_FAILED',
-        },
-      });
-
-    case types.CREATED_RESPONSIBILITY_SET:
-      return Object.assign({}, state, {
-        responsibilitySetStatus: {
-          error: null,
-          code: 'RESPONSIBILITY_SET_CREATED',
-        },
-      });
-
-    case types.CREATED_USER:
-      return Object.assign({}, state, {
-        userStatus: {
-          error: null,
-          code: 'USER_CREATED',
-        },
-      });
-
-    case types.UPDATED_USER:
-      return Object.assign({}, state, {
-        userStatus: {
-          error: null,
-          code: 'USER_UPDATED',
-        },
-      });
-
-    case types.CREATED_ENTITY_TYPE:
-      return Object.assign({}, state, {
-        entityTypeStatus: {
-          error: null,
-          code: 'ENTITY_TYPE_CREATED',
-        },
-      });
-
-    case types.FAILED_CREATING_ENTITY_TYPE:
-      return Object.assign({}, state, {
-        entityTypeStatus: {
-          error: action.payLoad,
-          code: 'ENTITY_TYPE_CREATED_FAILED',
-        },
-      });
-
-    case types.UPDATED_RESPONSIBILITY_SET:
-      return Object.assign({}, state, {
-        responsibilitySetStatus: {
-          error: null,
-          code: 'RESPONSIBILITY_SET_UPDATED',
-        },
-      });
-
-    case types.UPDATED_ENTITY_TYPE:
-      return Object.assign({}, state, {
-        entityTypeStatus: {
-          error: null,
-          code: 'ENTITY_TYPE_UPDATED',
-        },
-      });
-
-    case types.CHANGED_EVENT_FILTER_TYPE:
-      return Object.assign({}, state, {
-        userNotifications: changeFilterValue(
+const organizationSlice = createSlice({
+  name: 'organization',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(types.RECEIVED_ROLES, (state, action) => {
+        state.roles = action.payLoad;
+      })
+      .addCase(types.CREATED_ROLE, state => setStatus(state, 'roleStatus', 'ROLE_CREATED'))
+      .addCase(types.FAILED_CREATING_ROLE, (state, action) =>
+        setStatus(state, 'roleStatus', 'ROLE_CREATED_FAILED', action.payLoad)
+      )
+      .addCase(types.RECEIVED_ORGANIZATIONS, (state, action) => {
+        state.organizations = action.payLoad;
+      })
+      .addCase(types.CREATED_ORGANIZATION, state =>
+        setStatus(state, 'organizationStatus', 'ORGANIZATION_CREATED')
+      )
+      .addCase(types.UPDATED_ORGANIZATION, state =>
+        setStatus(state, 'organizationStatus', 'ORGANIZATION_UPDATED')
+      )
+      .addCase(types.FAILED_CREATING_ORGANIZATION, (state, action) =>
+        setStatus(state, 'organizationStatus', 'ORGANIZATION_CREATED_FAILED', action.payLoad)
+      )
+      .addCase(types.CREATED_RESPONSIBILITY_SET, state =>
+        setStatus(state, 'responsibilitySetStatus', 'RESPONSIBILITY_SET_CREATED')
+      )
+      .addCase(types.UPDATED_RESPONSIBILITY_SET, state =>
+        setStatus(state, 'responsibilitySetStatus', 'RESPONSIBILITY_SET_UPDATED')
+      )
+      .addCase(types.CREATED_USER, state => setStatus(state, 'userStatus', 'USER_CREATED'))
+      .addCase(types.UPDATED_USER, state => setStatus(state, 'userStatus', 'USER_UPDATED'))
+      .addCase(types.CREATED_ENTITY_TYPE, state =>
+        setStatus(state, 'entityTypeStatus', 'ENTITY_TYPE_CREATED')
+      )
+      .addCase(types.FAILED_CREATING_ENTITY_TYPE, (state, action) =>
+        setStatus(state, 'entityTypeStatus', 'ENTITY_TYPE_CREATED_FAILED', action.payLoad)
+      )
+      .addCase(types.UPDATED_ENTITY_TYPE, state =>
+        setStatus(state, 'entityTypeStatus', 'ENTITY_TYPE_UPDATED')
+      )
+      .addCase(types.CHANGED_EVENT_FILTER_TYPE, (state, action) => {
+        state.userNotifications = changeFilterValue(
           state.userNotifications,
           'type',
           action.payLoad.index,
           action.payLoad.value
-        ),
-      });
-
-    case types.CHANGED_EVENT_FILTER_JOB_DOMAIN:
-      return Object.assign({}, state, {
-        userNotifications: changeJobDomainValue(
+        );
+      })
+      .addCase(types.CHANGED_EVENT_FILTER_JOB_DOMAIN, (state, action) => {
+        state.userNotifications = changeJobDomainValue(
           state.userNotifications,
           action.payLoad.index,
           action.payLoad.value
-        ),
-      });
-
-    case types.CHANGE_EVENT_FILTER_ACTION:
-      return Object.assign({}, state, {
-        userNotifications: changeFilterActions(
+        );
+      })
+      .addCase(types.CHANGE_EVENT_FILTER_ACTION, (state, action) => {
+        state.userNotifications = changeFilterActions(
           state.userNotifications,
           action.payLoad.index,
           action.payLoad.action,
           action.payLoad.isChecked
-        ),
-      });
-
-    case types.CHANGED_EVENT_FILTER_ORG_REF:
-      return Object.assign({}, state, {
-        userNotifications: changeFilterValue(
+        );
+      })
+      .addCase(types.CHANGED_EVENT_FILTER_ORG_REF, (state, action) => {
+        state.userNotifications = changeFilterValue(
           state.userNotifications,
           'organisationRef',
           action.payLoad.index,
           action.payLoad.organisationRef
-        ),
-      });
-
-    case types.UPDATED_NOTIFICATION_CONFIGURATION:
-      return Object.assign({}, state, {
-        userNotifications: state.userNotifications.map(un => {
+        );
+      })
+      .addCase(types.UPDATED_NOTIFICATION_CONFIGURATION, state => {
+        state.userNotifications.forEach(un => {
           delete un.isNew;
-          return un;
-        }),
-      });
-
-    case types.CHANGED_NOTIFICATION_TYPE:
-      return Object.assign({}, state, {
-        userNotifications: state.userNotifications.map((un, i) => {
-          if (i === action.payLoad.index) {
-            return {
-              ...un,
-              notificationType: action.payLoad.type,
-            };
-          }
-          return un;
-        }),
-      });
-
-    case types.CHANGE_EVENT_FILTER_STATE:
-      return Object.assign({}, state, {
-        userNotifications: changeFilterStates(
+        });
+      })
+      .addCase(types.CHANGED_NOTIFICATION_TYPE, (state, action) => {
+        const un = state.userNotifications[action.payLoad.index];
+        if (un) {
+          un.notificationType = action.payLoad.type;
+        }
+      })
+      .addCase(types.CHANGE_EVENT_FILTER_STATE, (state, action) => {
+        state.userNotifications = changeFilterStates(
           state.userNotifications,
           action.payLoad.index,
           action.payLoad.state,
           action.payLoad.isChecked
-        ),
-      });
-
-    case types.RECEIVED_ADMINISTRATIVE_ZONES:
-      return Object.assign({}, state, {
-        administrativeZones: action.payLoad,
-      });
-
-    case types.RECEIVED_CODESPACES:
-      return Object.assign({}, state, { codeSpaces: action.payLoad });
-
-    case types.RECEIVED_USERS:
-      return Object.assign({}, state, { users: action.payLoad });
-
-    case types.RECEIVED_M2M_CLIENTS:
-      return Object.assign({}, state, { m2mClients: action.payLoad });
-
-    case types.CREATED_M2M_CLIENT:
-    case types.UPDATED_M2M_CLIENT:
-      return Object.assign({}, state, {
-        m2mClientStatus: {
-          error: null,
-        },
-      });
-
-    case types.FAILED_M2M_CLIENT_OPERATION:
-      return Object.assign({}, state, {
-        m2mClientStatus: {
-          error: action.payLoad,
-        },
-      });
-
-    case types.RECEIVED_RESPONSIBILITES:
-      return Object.assign({}, state, { responsibilities: action.payLoad });
-
-    case types.RECEIVED_ENTITY_TYPES:
-      return Object.assign({}, state, { entityTypes: action.payLoad });
-
-    case types.RECEIVED_USER_NOTIFICATIONS:
-      return Object.assign({}, state, {
-        userNotifications: action.payLoad,
-        userNotificationsLoading: false,
-      });
-
-    case types.RECEIVED_EVENT_FILTER_TYPES:
-      return Object.assign({}, state, {
-        eventFilterTypes: action.payLoad,
-      });
-
-    case types.RECEIVED_JOB_DOMAINS:
-      return Object.assign({}, state, {
-        jobDomains: action.payLoad,
-      });
-
-    case types.RECEIVED_JOB_ACTIONS_FOR_DOMAIN:
-      return Object.assign({}, state, {
-        jobDomainActions: {
-          ...state.jobDomainActions,
-          [action.payLoad.domain]: action.payLoad.data,
-        },
-      });
-
-    case types.RECEIVED_EVENT_FILTER_STATES:
-      return Object.assign({}, state, {
-        eventFilterStates: action.payLoad,
-      });
-
-    case types.RECEIVED_NOTIFICATION_TYPES:
-      return Object.assign({}, state, {
-        notificationTypes: action.payLoad,
-      });
-
-    case types.ADDED_ADMIN_ZONE_REF:
-      return Object.assign({}, state, {
-        userNotifications: addAdminRef(
+        );
+      })
+      .addCase(types.RECEIVED_ADMINISTRATIVE_ZONES, (state, action) => {
+        state.administrativeZones = action.payLoad;
+      })
+      .addCase(types.RECEIVED_CODESPACES, (state, action) => {
+        state.codeSpaces = action.payLoad;
+      })
+      .addCase(types.RECEIVED_USERS, (state, action) => {
+        state.users = action.payLoad;
+      })
+      .addCase(types.RECEIVED_M2M_CLIENTS, (state, action) => {
+        state.m2mClients = action.payLoad;
+      })
+      .addCase(types.CREATED_M2M_CLIENT, state => {
+        state.m2mClientStatus = { error: null };
+      })
+      .addCase(types.UPDATED_M2M_CLIENT, state => {
+        state.m2mClientStatus = { error: null };
+      })
+      .addCase(types.FAILED_M2M_CLIENT_OPERATION, (state, action) => {
+        state.m2mClientStatus = { error: action.payLoad };
+      })
+      .addCase(types.RECEIVED_RESPONSIBILITES, (state, action) => {
+        state.responsibilities = action.payLoad;
+      })
+      .addCase(types.RECEIVED_ENTITY_TYPES, (state, action) => {
+        state.entityTypes = action.payLoad;
+      })
+      .addCase(types.RECEIVED_USER_NOTIFICATIONS, (state, action) => {
+        state.userNotifications = action.payLoad;
+        state.userNotificationsLoading = false;
+      })
+      .addCase(types.RECEIVED_EVENT_FILTER_TYPES, (state, action) => {
+        state.eventFilterTypes = action.payLoad;
+      })
+      .addCase(types.RECEIVED_JOB_DOMAINS, (state, action) => {
+        state.jobDomains = action.payLoad;
+      })
+      .addCase(types.RECEIVED_JOB_ACTIONS_FOR_DOMAIN, (state, action) => {
+        state.jobDomainActions[action.payLoad.domain] = action.payLoad.data;
+      })
+      .addCase(types.RECEIVED_EVENT_FILTER_STATES, (state, action) => {
+        state.eventFilterStates = action.payLoad;
+      })
+      .addCase(types.RECEIVED_NOTIFICATION_TYPES, (state, action) => {
+        state.notificationTypes = action.payLoad;
+      })
+      .addCase(types.ADDED_ADMIN_ZONE_REF, (state, action) => {
+        state.userNotifications = addAdminRef(
           state.userNotifications,
           action.payLoad.index,
           action.payLoad.id
-        ),
-      });
-
-    case types.REMOVED_ADMIN_ZONE_REF:
-      return Object.assign({}, state, {
-        userNotifications: removeAdminRef(
+        );
+      })
+      .addCase(types.REMOVED_ADMIN_ZONE_REF, (state, action) => {
+        state.userNotifications = removeAdminRef(
           state.userNotifications,
           action.payLoad.index,
           action.payLoad.id
-        ),
-      });
-
-    case types.ADDED_ENTITY_CLASS_REF:
-      return Object.assign({}, state, {
-        userNotifications: addEntityClassRef(
+        );
+      })
+      .addCase(types.ADDED_ENTITY_CLASS_REF, (state, action) => {
+        state.userNotifications = addEntityClassRef(
           state.userNotifications,
           action.payLoad.index,
           action.payLoad.entityClassRef
-        ),
-      });
-
-    case types.REMOVED_ENTITY_CLASS_REF:
-      return Object.assign({}, state, {
-        userNotifications: removeEntityClassRef(
+        );
+      })
+      .addCase(types.REMOVED_ENTITY_CLASS_REF, (state, action) => {
+        state.userNotifications = removeEntityClassRef(
           state.userNotifications,
           action.payLoad.index,
           action.payLoad.entityClassRef
-        ),
-      });
-
-    case types.DELETED_USER_NOTIFICATION:
-      return Object.assign({}, state, {
-        userNotifications: removeByIndex(state.userNotifications, action.payLoad),
-      });
-
-    case types.REQUESTED_USER_NOTIFICATION:
-      return Object.assign({}, state, {
-        userNotificationsLoading: true,
-      });
-
-    case types.ADDED_NEW_USER_NOTIFICATION:
-      return Object.assign({}, state, {
-        userNotifications: state.userNotifications.concat({
+        );
+      })
+      .addCase(types.DELETED_USER_NOTIFICATION, (state, action) => {
+        state.userNotifications.splice(action.payLoad, 1);
+      })
+      .addCase(types.REQUESTED_USER_NOTIFICATION, state => {
+        state.userNotificationsLoading = true;
+      })
+      .addCase(types.ADDED_NEW_USER_NOTIFICATION, state => {
+        state.userNotifications.push({
           enabled: false,
           isNew: true,
           notificationType: 'EMAIL',
@@ -348,25 +233,15 @@ const OrganizationReducer = (state = initialState, action) => {
             actions: [],
             states: [],
           },
-        }),
+        });
+      })
+      .addCase(types.ENABLED_USER_NOTIFICATION, (state, action) => {
+        const un = state.userNotifications[action.payLoad.index];
+        if (un) {
+          un.enabled = action.payLoad.enabled;
+        }
       });
+  },
+});
 
-    case types.ENABLED_USER_NOTIFICATION:
-      return Object.assign({}, state, {
-        userNotifications: state.userNotifications.map((un, i) => {
-          if (i === action.payLoad.index) {
-            return {
-              ...un,
-              enabled: action.payLoad.enabled,
-            };
-          }
-          return un;
-        }),
-      });
-
-    default:
-      return state;
-  }
-};
-
-export default OrganizationReducer;
+export default organizationSlice.reducer;

--- a/src/reducers/SuppliersReducer.js
+++ b/src/reducers/SuppliersReducer.js
@@ -14,6 +14,7 @@
  *
  */
 
+import { createSlice } from '@reduxjs/toolkit';
 import * as types from 'actions/actionTypes';
 
 const initialState = {
@@ -26,85 +27,69 @@ const initialState = {
   exportedFiles: null,
 };
 
-const SuppliersReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case types.ERRORS_SUPPLIERS:
-      return Object.assign({}, state, {
-        isLoading: false,
-        data: action.payLoad,
-        error: true,
+const suppliersSlice = createSlice({
+  name: 'suppliers',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(types.ERRORS_SUPPLIERS, (state, action) => {
+        state.isLoading = false;
+        state.data = action.payLoad;
+        state.error = true;
+      })
+      .addCase(types.RECEIVED_SUPPLIERS, (state, action) => {
+        const level1Providers = action.payLoad
+          .filter(p => p.chouetteInfo && p.chouetteInfo.migrateDataToProvider)
+          .sort((a, b) => a.name.localeCompare(b.name, 'nb'));
+        const level2Providers = action.payLoad
+          .filter(p => !(p.chouetteInfo && p.chouetteInfo.migrateDataToProvider))
+          .sort((a, b) => a.name.localeCompare(b.name, 'nb'));
+        state.isLoading = false;
+        state.data = level1Providers.concat(level2Providers);
+        state.error = false;
+      })
+      .addCase(types.REQUESTED_SUPPLIERS, state => {
+        state.isLoading = true;
+        state.error = false;
+      })
+      .addCase(types.SELECT_SUPPLIER, (state, action) => {
+        state.activeId = action.payLoad;
+      })
+      .addCase(types.RECEIVED_SUPPLIER_STATUS, (state, action) => {
+        state.SupplierStatusIsLoading = true;
+        state.statusList = action.payLoad;
+      })
+      .addCase(types.REQUESTED_SUPPLIER_STATUS, (state, action) => {
+        state.SupplierStatusIsLoading = false;
+        state.statusList = action.payLoad;
+      })
+      .addCase(types.SELECTED_ALL_SUPPLIERS, state => {
+        state.activeId = -1;
+        state.all_suppliers_selected = true;
+      })
+      .addCase(types.RECEIVED_EXPORTED_FILES, (state, action) => {
+        state.exportedFiles = action.payLoad;
+      })
+      .addCase(types.UNSELECTED_ALL_SUPPLIERS, state => {
+        state.all_suppliers_selected = false;
+      })
+      .addCase(types.REQUESTED_ALL_SUPPLIERS_STATUS, state => {
+        state.statusListAllProviders = [];
+      })
+      .addCase(types.RECEIVED_ALL_SUPPLIERS_STATUS, (state, action) => {
+        state.statusListAllProviders = action.payLoad;
+      })
+      .addCase(types.RECEIVED_GRAPH_STATUS, (state, action) => {
+        Object.assign(state, action.payLoad);
+      })
+      .addCase(types.RECEIVED_GRAPH_VERSIONS, (state, action) => {
+        Object.assign(state, action.payLoad);
+      })
+      .addCase(types.RECEIVED_TRANSPORT_MODES, (state, action) => {
+        state.allTransportModes = action.payLoad;
       });
-    case types.RECEIVED_SUPPLIERS: {
-      const level1Providers = action.payLoad
-        .filter(p => p.chouetteInfo && p.chouetteInfo.migrateDataToProvider)
-        .sort((a, b) => {
-          return a.name.localeCompare(b.name, 'nb');
-        });
+  },
+});
 
-      const level2Providers = action.payLoad
-        .filter(p => !(p.chouetteInfo && p.chouetteInfo.migrateDataToProvider))
-        .sort((a, b) => {
-          return a.name.localeCompare(b.name, 'nb');
-        });
-
-      return Object.assign({}, state, {
-        isLoading: false,
-        data: level1Providers.concat(level2Providers),
-        error: false,
-      });
-    }
-    case types.REQUESTED_SUPPLIERS:
-      return Object.assign({}, state, { isLoading: true, error: false });
-    case types.SELECT_SUPPLIER:
-      return Object.assign({}, state, { activeId: action.payLoad });
-    case types.RECEIVED_SUPPLIER_STATUS:
-      return Object.assign({}, state, {
-        SupplierStatusIsLoading: true,
-        statusList: action.payLoad,
-      });
-
-    case types.REQUESTED_SUPPLIER_STATUS:
-      return Object.assign({}, state, {
-        SupplierStatusIsLoading: false,
-        statusList: action.payLoad,
-      });
-
-    case types.SELECTED_ALL_SUPPLIERS:
-      return Object.assign({}, state, {
-        activeId: -1,
-        all_suppliers_selected: true,
-      });
-
-    case types.RECEIVED_EXPORTED_FILES:
-      return Object.assign({}, state, {
-        exportedFiles: action.payLoad,
-      });
-
-    case types.UNSELECTED_ALL_SUPPLIERS:
-      return Object.assign({}, state, { all_suppliers_selected: false });
-
-    case types.REQUESTED_ALL_SUPPLIERS_STATUS:
-      return Object.assign({}, state, { statusListAllProviders: [] });
-
-    case types.RECEIVED_ALL_SUPPLIERS_STATUS:
-      return Object.assign({}, state, {
-        statusListAllProviders: action.payLoad,
-      });
-
-    case types.RECEIVED_GRAPH_STATUS:
-      return Object.assign({}, state, { ...action.payLoad });
-
-    case types.RECEIVED_GRAPH_VERSIONS:
-      return Object.assign({}, state, { ...action.payLoad });
-
-    case types.RECEIVED_TRANSPORT_MODES:
-      return Object.assign({}, state, {
-        allTransportModes: action.payLoad,
-      });
-
-    default:
-      return state;
-  }
-};
-
-export default SuppliersReducer;
+export default suppliersSlice.reducer;

--- a/src/reducers/UserContextReducer.js
+++ b/src/reducers/UserContextReducer.js
@@ -14,6 +14,7 @@
  *
  */
 
+import { createSlice } from '@reduxjs/toolkit';
 import * as types from 'actions/actionTypes';
 
 const initialState = {
@@ -22,16 +23,15 @@ const initialState = {
   isOrganisationAdmin: false,
 };
 
-const UserContextReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case types.RECEIVED_USER_CONTEXT:
-      return Object.assign({}, state, {
-        ...action.payLoad,
-      });
+const userContextSlice = createSlice({
+  name: 'userContext',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(types.RECEIVED_USER_CONTEXT, (state, action) => {
+      Object.assign(state, action.payLoad);
+    });
+  },
+});
 
-    default:
-      return state;
-  }
-};
-
-export default UserContextReducer;
+export default userContextSlice.reducer;

--- a/src/reducers/UserReducer.js
+++ b/src/reducers/UserReducer.js
@@ -14,16 +14,20 @@
  *
  */
 
+import { createSlice } from '@reduxjs/toolkit';
 import { UPDATE_AUTH } from 'actions/actionTypes';
 
-const UserReducer = (state = {}, action) => {
-  switch (action.type) {
-    case UPDATE_AUTH:
-      return Object.assign({}, state, { auth: action.payLoad });
+const initialState = {};
 
-    default:
-      return state;
-  }
-};
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(UPDATE_AUTH, (state, action) => {
+      state.auth = action.payLoad;
+    });
+  },
+});
 
-export default UserReducer;
+export default userSlice.reducer;

--- a/src/reducers/UtilsReducer.js
+++ b/src/reducers/UtilsReducer.js
@@ -14,9 +14,10 @@
  *
  */
 
+import { createSlice } from '@reduxjs/toolkit';
 import * as types from 'actions/actionTypes';
 
-const intialState = {
+const initialState = {
   shouldUpdateProvider: false,
   editProviderModal: false,
   outboundFilelist: [],
@@ -40,115 +41,82 @@ const intialState = {
   },
 };
 
-const UtilsReducer = (state = intialState, action) => {
-  switch (action.type) {
-    case types.ADD_NOTIFICATION:
-      return Object.assign({}, state, {
-        notification: {
+const toggleSortOrder = (current, payLoad) => {
+  if (current.property === payLoad) {
+    return current.sortOrder >= 1 ? 0 : 1;
+  }
+  return 0;
+};
+
+const utilsSlice = createSlice({
+  name: 'utils',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(types.ADD_NOTIFICATION, (state, action) => {
+        state.notification = {
           message: action.message,
           level: action.level,
-        },
-      });
-
-    case types.APPEND_FILES_TO_OUTBOUND:
-      return Object.assign({}, state, {
-        outboundFilelist: [
-          ...state.outboundFilelist,
-          ...action.payLoad.filter(x => state.outboundFilelist.indexOf(x) === -1),
-        ],
-      });
-
-    case types.REMOVE_FILES_FROM_OUTBOUND:
-      return Object.assign({}, state, {
-        outboundFilelist: state.outboundFilelist.filter(x => action.payLoad.indexOf(x) === -1),
-      });
-
-    case types.RESET_OUTBOUND_FILES:
-      return Object.assign({}, state, { outboundFilelist: [] });
-
-    case types.UPDATE_FILES_TO_OUTBOUND:
-      return Object.assign({}, state, { outboundFilelist: action.payLoad });
-
-    case types.TOGGLE_EXPANDABLE_FOR_EVENT_WRAPPER:
-      return Object.assign({}, state, {
-        expandedEvents: toggleExpandedEvents(action.payLoad, state.expandedEvents),
-      });
-
-    case types.DISMISS_EDIT_PROVIDER_DIALOG:
-      return Object.assign({}, state, { editProviderModal: false });
-
-    case types.OPENED_EDIT_PROVIDER_DIALOG:
-      return Object.assign({}, state, {
-        shouldUpdateProvider: true,
-        editProviderModal: true,
-      });
-
-    case types.OPENED_NEW_PROVIDER_DIALOG:
-      return Object.assign({}, state, {
-        shouldUpdateProvider: false,
-        editProviderModal: true,
-      });
-
-    case types.SUCCESS_FETCH_PROVIDER:
-      return Object.assign({}, state, { supplierForm: action.payLoad });
-
-    case types.SORT_EVENTLIST_BY_COLUMN: {
-      let eventsSortOrder = 0;
-
-      if (state.eventListSortOrder.property === action.payLoad) {
-        eventsSortOrder = state.eventListSortOrder.sortOrder === 1 ? 0 : 1;
-      }
-
-      return Object.assign({}, state, {
-        eventListSortOrder: {
+        };
+      })
+      .addCase(types.APPEND_FILES_TO_OUTBOUND, (state, action) => {
+        const incoming = action.payLoad.filter(x => !state.outboundFilelist.includes(x));
+        state.outboundFilelist.push(...incoming);
+      })
+      .addCase(types.REMOVE_FILES_FROM_OUTBOUND, (state, action) => {
+        state.outboundFilelist = state.outboundFilelist.filter(x => !action.payLoad.includes(x));
+      })
+      .addCase(types.RESET_OUTBOUND_FILES, state => {
+        state.outboundFilelist = [];
+      })
+      .addCase(types.UPDATE_FILES_TO_OUTBOUND, (state, action) => {
+        state.outboundFilelist = action.payLoad;
+      })
+      .addCase(types.TOGGLE_EXPANDABLE_FOR_EVENT_WRAPPER, (state, action) => {
+        const idx = state.expandedEvents.indexOf(action.payLoad);
+        if (idx === -1) {
+          state.expandedEvents.push(action.payLoad);
+        } else {
+          state.expandedEvents.splice(idx, 1);
+        }
+      })
+      .addCase(types.DISMISS_EDIT_PROVIDER_DIALOG, state => {
+        state.editProviderModal = false;
+      })
+      .addCase(types.OPENED_EDIT_PROVIDER_DIALOG, state => {
+        state.shouldUpdateProvider = true;
+        state.editProviderModal = true;
+      })
+      .addCase(types.OPENED_NEW_PROVIDER_DIALOG, state => {
+        state.shouldUpdateProvider = false;
+        state.editProviderModal = true;
+      })
+      .addCase(types.SUCCESS_FETCH_PROVIDER, (state, action) => {
+        state.supplierForm = action.payLoad;
+      })
+      .addCase(types.SORT_EVENTLIST_BY_COLUMN, (state, action) => {
+        state.eventListSortOrder = {
           property: action.payLoad,
-          sortOrder: eventsSortOrder,
-        },
-      });
-    }
-
-    case types.SORT_CHOUETTE_ALL_BY_COLUMN: {
-      let chouetteAllSortOrder = 0;
-
-      if (state.chouetteListAllSortOrder.property === action.payLoad) {
-        chouetteAllSortOrder = state.chouetteListAllSortOrder.sortOrder >= 1 ? 0 : 1;
-      }
-
-      return Object.assign({}, state, {
-        chouetteListAllSortOrder: {
+          sortOrder: toggleSortOrder(state.eventListSortOrder, action.payLoad),
+        };
+      })
+      .addCase(types.SORT_CHOUETTE_ALL_BY_COLUMN, (state, action) => {
+        state.chouetteListAllSortOrder = {
           property: action.payLoad,
-          sortOrder: chouetteAllSortOrder,
-        },
-      });
-    }
-
-    case types.SORT_CHOUETTE_BY_COLUMN: {
-      let chouetteSortOrder = 0;
-
-      if (state.chouetteListSortOrder.property === action.payLoad) {
-        chouetteSortOrder = state.chouetteListSortOrder.sortOrder >= 1 ? 0 : 1;
-      }
-
-      return Object.assign({}, state, {
-        chouetteListSortOrder: {
+          sortOrder: toggleSortOrder(state.chouetteListAllSortOrder, action.payLoad),
+        };
+      })
+      .addCase(types.SORT_CHOUETTE_BY_COLUMN, (state, action) => {
+        state.chouetteListSortOrder = {
           property: action.payLoad,
-          sortOrder: chouetteSortOrder,
-        },
+          sortOrder: toggleSortOrder(state.chouetteListSortOrder, action.payLoad),
+        };
+      })
+      .addCase(types.CONFIG_LOADED, state => {
+        state.isConfigLoaded = true;
       });
-    }
+  },
+});
 
-    case types.CONFIG_LOADED:
-      return Object.assign({}, state, { isConfigLoaded: true });
-
-    default:
-      return state;
-  }
-};
-
-const toggleExpandedEvents = (index, expanded) => {
-  if (expanded.indexOf(index) === -1) return expanded.concat(index);
-
-  return expanded.filter(item => item !== index);
-};
-
-export default UtilsReducer;
+export default utilsSlice.reducer;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -20,10 +20,14 @@ import rootReducer from 'reducers';
 export default function makeStore() {
   const store = configureStore({
     reducer: rootReducer,
-    // RTK's defaults give us thunk + immutability/serializability checks (dev)
-    // + Redux DevTools integration. The existing `(dispatch, getState) => …`
-    // thunks scattered through `src/actions/` continue to work unchanged;
-    // PR-B will rewrite them as `createAsyncThunk`.
+    // Marduk stores axios cancel-token functions in state (pre-AbortController
+    // pattern); disable the serializability check until a follow-up swaps to
+    // AbortController. RTK's defaults still give us thunk + Redux DevTools
+    // integration; existing `(dispatch, getState) => …` thunks work unchanged.
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+      }),
   });
 
   if (import.meta.hot) {


### PR DESCRIPTION
Second of four PRs for Phase 2 (inanna-style modernization). Foundation-only change: all 7 reducers move to RTK's `createSlice`. State shape is unchanged so the 31 `connect()` sites continue working — they read from the same state paths (`state.SuppliersReducer.data` etc.).

## What changed

Each reducer's switch statement becomes `createSlice({ ..., extraReducers: builder => builder.addCase(types.X, ...) })`, referencing the existing constants in `src/actions/actionTypes.js`. Object.assign-style updates are rewritten as Immer-style mutations.

| reducer | scope |
|---|---|
| `AppReducer` | `TOGGLE_MENU` |
| `UserReducer` | `UPDATE_AUTH` |
| `UserContextReducer` | `RECEIVED_USER_CONTEXT` |
| `UtilsReducer` | notifications, outbound filelist, sort orders, modal flags |
| `SuppliersReducer` | providers list, status lists, transport modes, exported files, graph status/versions |
| `MardukReducer` | pipeline op state (import/export/transfer/delete/build/fetch/validate), filenames, chouette jobs + filters, cancel tokens |
| `OrganizationReducer` | roles, orgs, users, m2m clients, responsibilities, entity types, user notifications |

The long Marduk pipeline-op cases collapse into a small `setOpData/setRequesting` helper.

`store.js`: disable the default `serializableCheck` middleware — `Marduk` state holds axios cancel-token functions (legacy pre-AbortController pattern). A follow-up will migrate to AbortController and re-enable the check.

## Why not also migrate thunks?

PR-B's original plan called for `createAsyncThunk` migration too, but the existing reducers cross-listen on shared action types (`SELECTED_ALL_SUPPLIERS` is handled by both `SuppliersReducer` and `MardukReducer`). Cleanly moving to slice-owned actions requires unwinding that and rewriting all ~80 thunks in `SuppliersActions`/`OrganizationRegisterActions` — too big to bundle with the reducer migration safely. Deferred to a follow-up sub-PR.

## Out of scope

- thunks → `createAsyncThunk`
- collapsing `actions/actionTypes.js` into slice-owned actions
- `AbortController` for chouette job polling
- `.jsx` → `.tsx`, class → function, `connect` → hooks (PR-C)
- `moment` → `date-fns`, `uuid` bump (PR-D)

## Verification

- [x] `npx tsc -b --noEmit` clean
- [x] `npx eslint .` — 0 errors (6 pre-existing warnings)
- [x] `npx prettier --check .` clean
- [x] `npm test` — 16/16
- [x] `npm run build` clean (bundle ~476 KB gzip)
- [ ] **Manual browser sanity**: full app flow — providers list loads, provider selection updates state, chouette jobs poll, user notifications render, M2M client CRUD, role assignments. Selectors are unchanged so behavior should be identical.