### PR TITLE
Pick up two more non-major bumps Renovate had open

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.1
+          node-version: 22.22.3
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@v4

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.22.1
+          node-version: 22.22.3
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react": "19.2.7",
         "react-chartjs-2": "5.3.1",
         "react-dom": "19.2.7",
-        "react-dropzone": "14.3.8",
+        "react-dropzone": "14.4.1",
         "react-icons": "5.6.0",
         "react-oidc-context": "3.3.1",
         "react-redux": "9.3.0",
@@ -5532,9 +5532,9 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "14.3.8",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
-      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "version": "14.4.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
+      "integrity": "sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==",
       "license": "MIT",
       "dependencies": {
         "attr-accept": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react": "19.2.7",
     "react-chartjs-2": "5.3.1",
     "react-dom": "19.2.7",
-    "react-dropzone": "14.3.8",
+    "react-dropzone": "14.4.1",
     "react-icons": "5.6.0",
     "react-oidc-context": "3.3.1",
     "react-redux": "9.3.0",


### PR DESCRIPTION
- react-dropzone 14.3.8 → 14.4.1 (14.x patch line; npm outdated only showed the 15.x major)
- node 22.22.1 → 22.22.3 in the two firebase-hosting GH Actions workflows