### PR TITLE
Fix events & validation-reports tabs in local auth-bypass mode

### DIFF
--- a/src/config/environments/local.json
+++ b/src/config/environments/local.json
@@ -10,6 +10,10 @@
   "endpointBase": "/",
   "chouetteBaseUrl": "http://localhost:21080/",
   "udugBaseUrl": "/netex-validation-reports/",
+  "timetableEventsApiUrl": "http://localhost:21004/services/events/timetable",
+  "timetableAdminApiUrl": "http://localhost:21080/services/timetable_admin",
+  "timetableValidationApiUrl": "http://localhost:21081/services/validation-report",
+  "kililiApiUrl": "http://localhost:21090/graphql",
   "enturPartnerUrl": "",
   "defaultAuthMethod": "local",
   "mockOauth2TokenUrl": "http://localhost:21999/default/token"

--- a/src/screens/netexValidationReports/hooks/useReport.ts
+++ b/src/screens/netexValidationReports/hooks/useReport.ts
@@ -16,21 +16,30 @@ export const useReport = (codespace: string, id: string) => {
 
   useEffect(() => {
     const fetchReport = async () => {
-      const accessToken = await getToken();
-      const response = await fetch(`${timetableValidationApiUrl}/${codespace}/${id}`, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Et-Client-Name': 'entur-ninkasi',
-        },
-      });
-      if (response.ok) {
-        const fetched = (await response.json()) as ValidationReport;
-        setReport(fetched);
-        setError(undefined);
-      } else {
+      try {
+        const accessToken = await getToken();
+        const response = await fetch(`${timetableValidationApiUrl}/${codespace}/${id}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Et-Client-Name': 'entur-ninkasi',
+          },
+        });
+        if (response.ok) {
+          const fetched = (await response.json()) as ValidationReport;
+          setReport(fetched);
+          setError(undefined);
+        } else {
+          setError({
+            status: response.status,
+            statusText: response.statusText,
+          });
+        }
+      } catch (e) {
+        // Network failure, unreachable backend, or non-JSON body: surface a
+        // clean error instead of an unhandled promise rejection.
         setError({
-          status: response.status,
-          statusText: response.statusText,
+          status: 0,
+          statusText: e instanceof Error ? e.message : String(e),
         });
       }
     };

--- a/src/utils/useAccessToken.ts
+++ b/src/utils/useAccessToken.ts
@@ -1,9 +1,13 @@
 import { useCallback } from 'react';
-import { useAuth } from 'react-oidc-context';
+import { useAuth } from '@/auth';
 
 /**
- * Hook form of the access-token getter. Mirrors the shape of `withAuth`'s
- * `getToken` prop so it can be used directly inside hooks and effects.
+ * Hook that returns a `getToken()` callback resolving to the current access
+ * token (or '' if unauthenticated), for use inside hooks and effects.
+ *
+ * Imports `useAuth` from `@/auth` — not `react-oidc-context` directly — so
+ * `auth.user` is also populated in local auth-bypass mode, where there is no
+ * OIDC provider. See `src/auth/index.ts`.
  */
 export const useAccessToken = () => {
   const auth = useAuth();


### PR DESCRIPTION
- useAccessToken: import useAuth from @/auth (not react-oidc-context) so auth.user is populated in local auth-bypass mode — fixes the Events tab crash.
- useReport: wrap the fetch in try/catch so an unreachable/non-JSON backend surfaces a clean error instead of an unhandled rejection.
- local.json: add the timetable events/admin/validation and kilili API URLs the inlined tabs read.