### PR TITLE
Bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -10,13 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.3.1
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 22.22.3
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5.0.5
         env:
           cache-name: cache-node-modules
         with:
@@ -38,7 +38,7 @@ jobs:
         env:
           REACT_APP_VERSION: ${{ github.sha }}
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: build
           path: |
@@ -48,9 +48,9 @@ jobs:
     needs: [build]
     environment: 'dev'
     steps:
-      - uses: actions/checkout@v4.3.1
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
       - name: Copy favicon
         run: cp build/nin-d.ico build/favicon.ico
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0
@@ -64,9 +64,9 @@ jobs:
     needs: [deploy_dev]
     environment: 'staging'
     steps:
-      - uses: actions/checkout@v4.3.1
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
       - name: Copy favicon
         run: cp build/nin-s.ico build/favicon.ico
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0
@@ -80,9 +80,9 @@ jobs:
     needs: [deploy_dev, deploy_staging]
     environment: 'prod'
     steps:
-      - uses: actions/checkout@v4.3.1
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
       - name: Copy favicon
         run: cp build/nin-p.ico build/favicon.ico
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -8,13 +8,13 @@ jobs:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.3.1
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 22.22.3
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5.0.5
         env:
           cache-name: cache-node-modules
         with:
@@ -36,7 +36,7 @@ jobs:
         env:
           REACT_APP_VERSION: ${{ github.sha }}
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: build
           path: |

--- a/.github/workflows/maintenance_mode_dev.yml
+++ b/.github/workflows/maintenance_mode_dev.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: 'dev'
     steps:
-      - uses: actions/checkout@v4.3.1
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
       - name: Copy maintenance mode file
         run: mkdir build && cp public/maintenance.html build/index.html
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0

--- a/.github/workflows/maintenance_mode_production.yml
+++ b/.github/workflows/maintenance_mode_production.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: 'prod'
     steps:
-      - uses: actions/checkout@v4.3.1
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
       - name: Copy maintenance mode file
         run: mkdir build && cp public/maintenance.html build/index.html
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0

--- a/.github/workflows/maintenance_mode_staging.yml
+++ b/.github/workflows/maintenance_mode_staging.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: 'staging'
     steps:
-      - uses: actions/checkout@v4.3.1
+      - uses: actions/checkout@v6.0.3
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
       - name: Copy maintenance mode file
         run: mkdir build && cp public/maintenance.html build/index.html
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0


### PR DESCRIPTION
Apply the four open Renovate suggestions for GitHub Actions versions in a single PR. Workflow-only — no app source changes.

| action | from | to |
|---|---|---|
| `actions/checkout` | v4.3.1 | v6.0.3 |
| `actions/setup-node` | v4.4.0 | v6.4.0 |
| `actions/cache` | v4.3.0 | v5.0.5 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |
| `actions/download-artifact` | v4.3.0 | v8.0.1 |

## Notes on breaking changes

**Artifact actions (v4 → v7 / v8).** GitHub renumbered after the v4 cutover that enforced per-artifact-name uniqueness within a job. Our workflows have one upload per job (the `build` job in `firebase-hosting-merge.yml`) and re-download the same named artifact across the dev/staging/prod hosting-deploy jobs — that pattern is unchanged.

**`actions/setup-node@v6`** defaults to Node 24 if no `node-version` is given; we always pin (`22.22.3` per #572), so the default change is moot.

**`actions/checkout@v6`** runs on the Node 24 runtime — same as the rest of v6 actions.

## Closes

Renovate PRs to drop on merge: #574, #466, #448, #270.

## Verification

- Workflow-only — no `tsc` / `eslint` / `prettier` / `npm test` impact.
- Real verification happens when CI runs on this PR.