### PR TITLE
Fix artifact download path after upload-artifact v4 → v7 bump

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -49,8 +49,11 @@ jobs:
     environment: 'dev'
     steps:
       - uses: actions/checkout@v6.0.3
-      - name: Download all workflow run artifacts
+      - name: Download build artifact
         uses: actions/download-artifact@v8.0.1
+        with:
+          name: build
+          path: build
       - name: Copy favicon
         run: cp build/nin-d.ico build/favicon.ico
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0
@@ -65,8 +68,11 @@ jobs:
     environment: 'staging'
     steps:
       - uses: actions/checkout@v6.0.3
-      - name: Download all workflow run artifacts
+      - name: Download build artifact
         uses: actions/download-artifact@v8.0.1
+        with:
+          name: build
+          path: build
       - name: Copy favicon
         run: cp build/nin-s.ico build/favicon.ico
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0
@@ -81,8 +87,11 @@ jobs:
     environment: 'prod'
     steps:
       - uses: actions/checkout@v6.0.3
-      - name: Download all workflow run artifacts
+      - name: Download build artifact
         uses: actions/download-artifact@v8.0.1
+        with:
+          name: build
+          path: build
       - name: Copy favicon
         run: cp build/nin-p.ico build/favicon.ico
       - uses: FirebaseExtended/action-hosting-deploy@v0.10.0


### PR DESCRIPTION
Hotfix. CI was failing on the post-build deploy jobs with:

\`\`\`
Run cp build/nin-d.ico build/favicon.ico
cp: cannot stat 'build/nin-d.ico': No such file or directory
Error: Process completed with exit code 1.
\`\`\`

## Root cause

\`upload-artifact@v4\` stripped a single-path prefix when storing the artifact (so an upload with \`path: build\` produced an artifact whose root contained \`index.html\`, \`nin-d.ico\`, etc.). **\`v5+\` preserves the workspace-relative path inside the artifact**, so the same upload now produces an artifact whose root contains \`build/index.html\`, \`build/nin-d.ico\`, …

The deploy jobs were using \`actions/download-artifact\` with no \`name\` specified — "download all artifacts" mode, which wraps each artifact in a subdirectory matching its name. So the v7-uploaded artifact landed at \`./build/build/nin-d.ico\` and the favicon \`cp\` step failed.

## Fix

Switch the three deploy-job download steps to \`name: build, path: build\`. That extracts the artifact's \`build/*\` entries directly into \`./build/\`, restoring the expected layout.

\`\`\`yaml
- name: Download build artifact
  uses: actions/download-artifact@v8.0.1
  with:
    name: build
    path: build
\`\`\`

Regression introduced by 6c5dd62 (#580 "Bump GitHub Actions to latest majors").

## Other workflows checked

- \`firebase-hosting-pull-request.yml\`: single job that builds + deploys; no download step. Unaffected.
- \`maintenance_mode_{dev,staging,production}.yml\`: download all artifacts then \`mkdir build && cp public/maintenance.html build/index.html\` — they're \`workflow_dispatch\`-triggered with no associated artifacts, so download-artifact is a no-op there. Unaffected.

## Verification

Workflow-only — CI on this PR will verify directly. Once merged, the regular master push pipeline should go green.