### PR TITLE
Node 22 → 24 in CI + @types/node 22 → 24

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6.0.3
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22.22.3
+          node-version: 24.16.0
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@v5.0.5

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6.0.3
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22.22.3
+          node-version: 24.16.0
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@v5.0.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       "devDependencies": {
         "@eslint/js": "9.39.4",
         "@testing-library/jest-dom": "6.9.1",
-        "@types/node": "22.19.15",
+        "@types/node": "24.13.0",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.2",
@@ -1937,13 +1937,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "24.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
+      "integrity": "sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -5773,9 +5773,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@eslint/js": "9.39.4",
     "@testing-library/jest-dom": "6.9.1",
-    "@types/node": "22.19.15",
+    "@types/node": "24.13.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",


### PR DESCRIPTION
Two coupled bumps tracking the same Node major.

- `.github/workflows/firebase-hosting-{merge,pull-request}.yml`: `node-version` 22.22.3 → 24.16.0
- `@types/node` 22.19.15 → 24.13.0

Node 24 is the current active LTS (cutover from 22 happened in October 2025).

## Verification

- [x] `npm install` clean
- [x] `npx tsc -b --noEmit` clean
- [x] `npm test` — 8/8
- [x] `npm run build` clean

CI on this PR will validate the workflow node-version change.

## Closes

Renovate PR #411.

## Remaining majors

- #511 eslint 9 → 10 (next — likely needs config tweaks)
- #378 eslint-plugin-react-hooks 5 → 7
- #550 MUI 7 → 9