### PR TITLE
MUI 7 → 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@emotion/react": "11.14.0",
         "@emotion/styled": "11.14.1",
-        "@mui/icons-material": "7.3.9",
-        "@mui/material": "7.3.9",
-        "@mui/x-date-pickers": "8.27.2",
+        "@mui/icons-material": "9.1.0",
+        "@mui/material": "9.1.0",
+        "@mui/x-date-pickers": "9.4.0",
         "@reduxjs/toolkit": "2.12.0",
         "axios": "1.17.0",
         "chai": "6.2.2",
@@ -880,9 +880,9 @@
       "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.11.tgz",
-      "integrity": "sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.1.0.tgz",
+      "integrity": "sha512-eZiO4x9hufIYiOosniu8RXituaRzUF+IRVxAID0lLwfmkjoleh88PPFmla194zZXp0yhicPjgEvmApI3tAAy2Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -890,12 +890,12 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.9.tgz",
-      "integrity": "sha512-BT+zPJXss8Hg/oEMRmHl17Q97bPACG4ufFSfGEdhiE96jOyR5Dz1ty7ZWt1fVGR0y1p+sSgEwQT/MNZQmoWDCw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.1.0.tgz",
+      "integrity": "sha512-HLrgXtO1Zo1w20fjMrFQ0caCka5CIxWQjydQkd8/DZ6rY2oW+gq5svDlze1meoO03QudNuElMigk4GmAUZU1BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -905,7 +905,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^7.3.9",
+        "@mui/material": "^9.1.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -916,22 +916,22 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
-      "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.1.0.tgz",
+      "integrity": "sha512-KV3EqUb50g0Mhxiv3pCMX1KpW/M+JGD2lrQelMcjWJ4ABKKU4yotS9G10nvqPRiI9ylZUeIf36UKxTY7jeyfcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/core-downloads-tracker": "^7.3.9",
-        "@mui/system": "^7.3.9",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.1.0",
+        "@mui/system": "^9.1.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.1.0",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.6",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -944,7 +944,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.9",
+        "@mui/material-pigment-css": "^9.1.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -965,13 +965,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.11.tgz",
-      "integrity": "sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.1.0.tgz",
+      "integrity": "sha512-U/5n2BcqAQ6gNehYqjuyRY8pHx5/TmWk2r5kpHJ/8F+YE+QomVXGJXK/ozsIRy760LQkVxWWVFcSa+sIFquV/g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/utils": "^7.3.11",
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.1.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -992,12 +992,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
-      "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.1.0.tgz",
+      "integrity": "sha512-kRplQAga6cQ5uKwJEAh6Mx/NLxnK2Zitas5B1osv1y2MAX97OV/5BTupEBYDbAbTwo4d+t+aDa5CqeGvSpxXgw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
+        "@babel/runtime": "^7.29.2",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -1026,16 +1026,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.11.tgz",
-      "integrity": "sha512-7izwGWdNawAKpBKcRlx7f2gFnAAjmASBWvMcyX4YYEeLOFsbfGRbUYGInvnAcUeql3rPxI7F9Ft4oY2OLRz44g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.1.0.tgz",
+      "integrity": "sha512-zZExEpvOpvE/XuhLN9fABOVngR8KInCRwcEPI7cQBccqen6nkMyZWhiKf3GQ+3WHreAVLqbGYJwUSXGPGHrcmg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/private-theming": "^7.3.11",
-        "@mui/styled-engine": "^7.3.10",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.11",
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.1.0",
+        "@mui/styled-engine": "^9.1.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.1.0",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -1066,12 +1066,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.12",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
-      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1083,17 +1083,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
-      "integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.1.0.tgz",
+      "integrity": "sha512-ECZGCOdL+CtYrvfBsRx/gb0zSQjXIpAPF6Uk/0EHgGysHnedK1HBfONsOqCOsdPB59rv8S52U/8aVoNlO/c9jQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/types": "^7.4.12",
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3"
+        "react-is": "^19.2.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1113,14 +1113,14 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "8.27.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.27.2.tgz",
-      "integrity": "sha512-06LFkHFRXJ2O9DMXtWAA3kY0jpbL7XH8iqa8L5cBlN+8bRx/UVLKlZYlhGv06C88jF9kuZWY1bUgrv/EoY/2Ww==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.4.0.tgz",
+      "integrity": "sha512-YXZn+RNzCZ7iPhwoXCUHwvlqIgvefwPGaKRXztxniry55mruqnQDPFqYZTMO2DaWow496yzcAtLwEmG+K8pm0Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.5",
-        "@mui/x-internals": "8.26.0",
+        "@babel/runtime": "^7.29.7",
+        "@mui/utils": "9.0.1",
+        "@mui/x-internals": "^9.1.0",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -1136,8 +1136,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/material": "^7.3.0 || ^9.0.0",
+        "@mui/system": "^7.3.0 || ^9.0.0",
         "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
         "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
         "dayjs": "^1.10.7",
@@ -1178,14 +1178,44 @@
         }
       }
     },
-    "node_modules/@mui/x-internals": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.26.0.tgz",
-      "integrity": "sha512-B9OZau5IQUvIxwpJZhoFJKqRpmWf5r0yMmSXjQuqb5WuqM755EuzWJOenY48denGoENzMLT8hQpA0hRTeU2IPA==",
+    "node_modules/@mui/x-date-pickers/node_modules/@mui/utils": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.1.tgz",
+      "integrity": "sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.5",
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-9.1.0.tgz",
+      "integrity": "sha512-fVezTa1lU+Hb3y9UMI8D/iWXADhs0I8PaZqoh2LOUXjGEUJmKqwsRD19ZXInZsH2yu+YS0dqYMPDvzjYTTyo+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "9.0.0",
         "reselect": "^5.1.1",
         "use-sync-external-store": "^1.6.0"
       },
@@ -1198,6 +1228,36 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-internals/node_modules/@mui/utils": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz",
+      "integrity": "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@mui/icons-material": "7.3.9",
-    "@mui/material": "7.3.9",
-    "@mui/x-date-pickers": "8.27.2",
+    "@mui/icons-material": "9.1.0",
+    "@mui/material": "9.1.0",
+    "@mui/x-date-pickers": "9.4.0",
     "@reduxjs/toolkit": "2.12.0",
     "axios": "1.17.0",
     "chai": "6.2.2",

--- a/src/app/components/Menu.tsx
+++ b/src/app/components/Menu.tsx
@@ -54,10 +54,12 @@ export default function Menu({ open, onClose }: MenuProps) {
       open={open}
       onClose={onClose}
       ModalProps={{ keepMounted: true }}
-      PaperProps={{
-        sx: {
-          width: isMobile ? '100%' : DESKTOP_WIDTH,
-          ...themeColors,
+      slotProps={{
+        paper: {
+          sx: {
+            width: isMobile ? '100%' : DESKTOP_WIDTH,
+            ...themeColors,
+          },
         },
       }}
     >
@@ -88,7 +90,7 @@ export default function Menu({ open, onClose }: MenuProps) {
               onClick={onClose}
               selected={location.pathname === path}
             >
-              <ListItemText primary={text} primaryTypographyProps={{ style: { color: 'white' } }} />
+              <ListItemText primary={text} slotProps={{ primary: { style: { color: 'white' } } }} />
             </ListItemButton>
           </ListItem>
         ))}

--- a/src/app/components/NotificationContainer.tsx
+++ b/src/app/components/NotificationContainer.tsx
@@ -95,8 +95,8 @@ const NotificationContainer = () => {
       open={open}
       autoHideDuration={4000}
       onClose={handleClose}
-      TransitionComponent={Slide}
-      TransitionProps={{ onExited: handleExited }}
+      slots={{ transition: Slide }}
+      slotProps={{ transition: { onExited: handleExited } }}
       anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
     >
       {currentNotification ? (

--- a/src/app/components/header/HeaderActions.tsx
+++ b/src/app/components/header/HeaderActions.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { Box, IconButton, Menu, MenuItem, Avatar, useTheme, Typography } from '@mui/material';
-import { HelpOutline, Menu as MenuIcon, OpenInNew } from '@mui/icons-material';
+import { HelpOutlined, Menu as MenuIcon, OpenInNew } from '@mui/icons-material';
 import { useAuth } from '../../../auth';
 import { useSelector } from 'react-redux';
 
@@ -87,7 +87,7 @@ export default function HeaderActions({ isMobile, onMenuIconClick }: HeaderActio
       </IconButton>
 
       <IconButton onClick={handleDocsMenuOpen} aria-label="documentation" sx={iconButtonStyles}>
-        <HelpOutline />
+        <HelpOutlined />
       </IconButton>
 
       <IconButton

--- a/src/modals/ModalEditProvider.tsx
+++ b/src/modals/ModalEditProvider.tsx
@@ -27,7 +27,7 @@ import {
 } from '@mui/material';
 import Button from '@mui/material/Button';
 import { Tooltip, styled } from '@mui/material';
-import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import HelpOutlinedIcon from '@mui/icons-material/HelpOutlined';
 import { useAppDispatch, useAppSelector } from 'store/hooks';
 import { useAccessToken } from '@/utils/useAccessToken';
 import * as SuppliersReducer from 'reducers/SuppliersReducer';
@@ -224,7 +224,7 @@ const ModalEditProvider = ({
   const toolTip = (title: string) => (
     <LightTooltip arrow placement="right" title={title}>
       <span className="question-icon">
-        <HelpOutlineIcon style={{ paddingTop: '5px' }} />
+        <HelpOutlinedIcon style={{ paddingTop: '5px' }} />
       </span>
     </LightTooltip>
   );

--- a/src/modals/UserRespSetPopover.tsx
+++ b/src/modals/UserRespSetPopover.tsx
@@ -48,7 +48,7 @@ const UserRespSetPopover = ({
       open={open}
       anchorEl={anchorEl}
       onClose={handleClose}
-      PaperProps={{ style: { maxHeight: '500px' } }}
+      slotProps={{ paper: { style: { maxHeight: '500px' } } }}
     >
       {sorted.map(r => (
         <MenuItem

--- a/src/screens/providers/components/ChouetteAllJobs.tsx
+++ b/src/screens/providers/components/ChouetteAllJobs.tsx
@@ -128,7 +128,7 @@ const ChouetteAllJobs = () => {
         <Box sx={{ mb: 2 }}>
           <Grid container spacing={2} alignItems="center">
             <Grid item xs={1}>
-              <Typography variant="subtitle2" fontWeight="bold">
+              <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
                 Status
               </Typography>
             </Grid>
@@ -227,7 +227,7 @@ const ChouetteAllJobs = () => {
         <Box sx={{ mb: 2 }}>
           <Grid container spacing={2} alignItems="baseline">
             <Grid item xs={1}>
-              <Typography variant="subtitle2" fontWeight="bold">
+              <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
                 Action
               </Typography>
             </Grid>

--- a/src/screens/providers/components/ChouetteJobDetails.tsx
+++ b/src/screens/providers/components/ChouetteJobDetails.tsx
@@ -125,7 +125,7 @@ const ChouetteJobDetails = () => {
         <Box sx={{ mb: 2 }}>
           <Grid container spacing={2} alignItems="center">
             <Grid item xs={1}>
-              <Typography variant="subtitle2" fontWeight="bold">
+              <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
                 Status
               </Typography>
             </Grid>
@@ -224,7 +224,7 @@ const ChouetteJobDetails = () => {
         <Box sx={{ mb: 2 }}>
           <Grid container spacing={2} alignItems="baseline">
             <Grid item xs={1}>
-              <Typography variant="subtitle2" fontWeight="bold">
+              <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
                 Action
               </Typography>
             </Grid>

--- a/src/screens/providers/components/EventExpandableContent.tsx
+++ b/src/screens/providers/components/EventExpandableContent.tsx
@@ -34,13 +34,13 @@ const EventExpandableContent = ({ events, correlationId }: Props) => {
       <p>Events for {correlationId}</p>
       <Grid container spacing={2}>
         <Grid item md={4}>
-          <Typography fontWeight="bold">Action</Typography>
+          <Typography sx={{ fontWeight: 'bold' }}>Action</Typography>
         </Grid>
         <Grid item md={4}>
-          <Typography fontWeight="bold">Date</Typography>
+          <Typography sx={{ fontWeight: 'bold' }}>Date</Typography>
         </Grid>
         <Grid item md={4}>
-          <Typography fontWeight="bold">State</Typography>
+          <Typography sx={{ fontWeight: 'bold' }}>State</Typography>
         </Grid>
       </Grid>
       <Divider sx={{ my: 1 }} />

--- a/src/screens/providers/components/events/components/FilterButtonTray.tsx
+++ b/src/screens/providers/components/events/components/FilterButtonTray.tsx
@@ -28,7 +28,7 @@ const FilterButtonTray = ({
           {label}
         </Typography>
       </Box>
-      <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+      <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
         {buttonConfig.fields.map(field => {
           const selected = field.id === activeButtonId;
           return (

--- a/src/screens/providers/components/lineStatistics/components/linesValidity/linesFilters/sortingChips.tsx
+++ b/src/screens/providers/components/lineStatistics/components/linesValidity/linesFilters/sortingChips.tsx
@@ -32,7 +32,7 @@ export const SortingChips = ({ sorting, setSorting }: Props) => {
   return (
     <Box sx={{ mb: '20px' }}>
       <FormLabel sx={{ display: 'block', mb: 1 }}>{titleText(locale).sortLines}</FormLabel>
-      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+      <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
         {chipOption(
           1,
           current,

--- a/src/screens/providers/components/lineStatistics/components/linesValidity/linesFilters/validityChips.tsx
+++ b/src/screens/providers/components/lineStatistics/components/linesValidity/linesFilters/validityChips.tsx
@@ -16,7 +16,7 @@ export const ValidityChips = ({ selectedValidity, setSelectedValidity }: Props) 
   return (
     <Box sx={{ mb: '20px' }}>
       <FormLabel sx={{ display: 'block', mb: 1 }}>{titleText(locale).selectLines}</FormLabel>
-      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+      <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
         {options.map(value => (
           <Chip
             key={value}


### PR DESCRIPTION
The last major bump from Renovate's queue. Skips MUI 8 entirely — the existing Renovate `material-ui-monorepo` PR is only tracking patches inside v7 (it auto-skipped the major).

| | from | to |
|---|---|---|
| @mui/material | 7.3.9 | 9.1.0 |
| @mui/icons-material | 7.3.9 | 9.1.0 |
| @mui/x-date-pickers | 8.27.2 | 9.4.0 |

## Required adjustments (11 files)

### `<Comp>Props` → `slotProps`

MUI v8 standardised the customization API around `slots` / `slotProps`. The old per-component props are gone:

- `Drawer.PaperProps` → `slotProps.paper` (`Menu.tsx`)
- `Menu.PaperProps` → `slotProps.paper` (`UserRespSetPopover.tsx`)
- `ListItemText.primaryTypographyProps` → `slotProps.primary` (`Menu.tsx`)
- `Snackbar.TransitionComponent` + `TransitionProps` → `slots.transition` + `slotProps.transition` (`NotificationContainer.tsx`)

### Typography `fontWeight` prop removed

7 usages across `ChouetteJobDetails`, `ChouetteAllJobs`, `EventExpandableContent`. Replaced with `sx={{ fontWeight: 'bold' }}`.

### Stack `flexWrap` prop no longer accepted

3 usages in chip-tray components. Moved into `sx={{ flexWrap: 'wrap' }}` (`useFlexGap` stays as a top-level prop).

### Icon rename

`HelpOutline` → `HelpOutlined` (named import in `HeaderActions.tsx`, default import path in `ModalEditProvider.tsx`).

## What I left alone

`adaptV4Theme` is still exported in MUI 9 (still deprecated). The App.tsx theme is still being built through it. An inanna-style theme rewrite can sweep it out separately.

## Verification

- [x] `npx tsc -b --noEmit` clean
- [x] `npx eslint .` — 0 errors, 0 warnings
- [x] `npx prettier --check .` clean
- [x] `npm test` — 8/8
- [x] `npm run build` clean
- [x] Bundle: 426 → 431 KB gzip (+5 KB, new MUI internals)
- [ ] **Manual browser sanity required** — slotProps + Typography fontWeight changes are visual. Click through: provider chouette jobs (jobsfilter date picker still wires up via x-date-pickers v9), provider events tab (filter chips), line statistics page (validity/sorting chips), menu drawer, every modal.

## Closes

Renovate #550 (material-ui-monorepo).

## All Renovate majors now addressed

This was the last open major in Renovate's queue. The remaining Renovate PRs are either:
- Closed by an earlier merge of this series
- Action-related (already in #580 / #583)
- Patches Renovate will reopen against the new versions