### PR TITLE
Rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,3 @@ Two GitHub Actions workflows in `.github/workflows/`:
 `firebase.json` carves out a no-store cache rule for `/config.json` (above the
 catch-all `*.json` 1-year rule) so runtime config changes propagate
 immediately.
-
-## Related repos
-
-- [enki](https://github.com/entur/enki), [nirgali](https://github.com/entur/nirgali) — modernized sister admin apps, reference for the
-  MUI + RTK patterns used here.
-- [inanna](https://github.com/entur/inanna) — modernization template repo.
-- [netex-explorer](https://github.com/entur/netex-explorer) — reference for
-  the theme + runtime-config / env-badge pattern.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ the JSON and the deploy workflow.
 
 Each config carries:
 
-- `appEnv` — `local | dev | test | prod`
 - `envLabel` / `envLabelColor` — drives the chip next to the wordmark.
   Omitted for prod so the chip disappears.
 - API base URLs for each upstream service (timetable-admin, providers,

--- a/README.md
+++ b/README.md
@@ -1,53 +1,149 @@
 # Ninkasi
 
-This is the private admin GUI for managing the data pipeline and inspection of data status. Deployed to https://ninkasi.dev.entur.org/ and others.
+Internal admin GUI for managing Entur's NeTEx data pipeline and inspecting data
+status. Used by Entur staff to register and configure data providers, run
+pipeline operations (import / validate / transfer / export), and look at
+delivery and processing history.
 
-## Run the app
+Production: <https://ninkasi.entur.org>
+Staging: <https://ninkasi.staging.entur.org>
+Dev: <https://ninkasi.dev.entur.org>
 
-### Dev
+## Stack
 
-```
+- React 19 + TypeScript, Vite 8 (rolldown)
+- MUI v9 with a thin Entur-token theme (`src/theme/theme.ts`)
+- Redux Toolkit (`@reduxjs/toolkit`) — slices in `src/reducers/`, async work via
+  `createAsyncThunk`
+- React Router v7
+- OIDC auth via `react-oidc-context`
+- Vitest + Testing Library
+- date-fns, axios
+- Deployed to Firebase Hosting via GitHub Actions
+
+The three former micro-frontends (NeTEx validation reports, events/upload,
+line-statistics) are now inlined under `src/screens/providers/components/`.
+
+## Run locally
+
+```bash
 npm install
+npm run start          # vite dev server on :9000
+```
+
+Node 24 is required (the GitHub Actions workflow pins `node-version: 24.16.0`).
+
+By default the dev server reads `public/config.json`, which points at local
+mock services. To point a local dev server at the dev environment APIs instead:
+
+```bash
+cp public/config.dev.json public/config.json
 npm run start
 ```
 
-Requires Node.js v18 or newer.
-
-### Production
-
-```
-npm install
-npm run build
-npm start
-```
+`public/config.json` is gitignored from changes in this workflow — see
+"Configuration" below.
 
 ## Configuration
 
-We use convict.js for config. Set environment variables `PROVIDERS_BASE_URL`, `ORGANISATIONS_BASE_URL`, `TIMETABLE_ADMIN_BASE_URL`, `MAP_ADMIN_BASE_URL`
-and `EVENTS_BASE_URL` in order to override default configuration of these
-endpoints, e.g.
+Ninkasi uses **runtime config**: a single `config.json` is fetched at boot, no
+env vars are baked into the bundle. The repo carries four versions:
+
+| File                         | When it's served                                                  |
+| ---------------------------- | ----------------------------------------------------------------- |
+| `public/config.json`         | Local dev — points at the localhost mock services in this repo.   |
+| `public/config.dev.json`     | Copied over `config.json` by the GHA deploy step for the dev env. |
+| `public/config.staging.json` | Same, for staging.                                                |
+| `public/config.prod.json`    | Same, for prod.                                                   |
+
+The same build artifact ships to every environment; only the JSON differs.
+Adding or renaming an environment doesn't require a code change — just edit
+the JSON and the deploy workflow.
+
+Each config carries:
+
+- `appEnv` — `local | dev | test | prod`
+- `envLabel` / `envLabelColor` — drives the chip next to the wordmark.
+  Omitted for prod so the chip disappears.
+- API base URLs for each upstream service (timetable-admin, providers,
+  organisations, events, map-admin, chouette, …)
+- `auth0Domain` / `auth0ClientId` / `auth0Audience` /
+  `auth0ClaimsNamespace` — OIDC settings
+- `defaultAuthMethod` — `auth0` everywhere except local, which uses a mock
+  OAuth2 server (`mockOauth2TokenUrl`)
+
+The `Config` type is in `src/contexts/ConfigContext.tsx`. Components read
+config via `useConfig()` or `window.config`.
+
+## Scripts
+
+| Script            | What it does                                            |
+| ----------------- | ------------------------------------------------------- |
+| `npm run start`   | Vite dev server with HMR on port 9000                   |
+| `npm run build`   | Type-check (`tsc -b`) then production build to `build/` |
+| `npm run preview` | Serve the production build locally                      |
+| `npm test`        | Vitest watch                                            |
+| `npm run lint`    | ESLint (flat config in `eslint.config.js`)              |
+| `npm run check`   | Prettier check                                          |
+| `npm run format`  | Prettier write                                          |
+
+Pre-commit hook runs Prettier + ESLint via lint-staged.
+
+## Project layout
 
 ```
-ORGANISATIONS_BASE_URL=http://localhost:16001/services/organisations/ \
-  PROVIDERS_BASE_URL=http://localhost:16001/services/providers/ \
-  EVENTS_BASE_URL=http://localhost:10001/services/events/ \
-  TIMETABLE_ADMIN_BASE_URL=http://localhost:11002/services/timetable_admin/ \
-  MAP_ADMIN_BASE_URL=http://localhost:11002/services/map_admin/ \
-  npm start dev
+src/
+├── actions/         Legacy thin re-export shims (kept for one-line back-compat)
+├── app/             App shell — Router, Header/Menu, NotificationContainer,
+│                    LoadingState / EmptyState / ErrorState
+├── auth/            OIDC AuthProvider, useAccessToken hook
+├── config/          fetchConfig.ts — runtime config loader
+├── contexts/        ConfigContext (typed runtime config)
+├── modals/          All dialogs (provider editor, role / responsibility /
+│                    entity-type / user / M2M client editors, confirmations)
+├── reducers/        RTK slices (Suppliers, Marduk, Utils, Organization,
+│                    UserContext, App)
+├── screens/         Top-level routes
+│   ├── common/      SelectSupplier
+│   ├── organization/Permissions admin (sidebar of users/roles/orgs/etc.)
+│   └── providers/   Timetable-pipeline admin (provider list, tabs for
+│                    migrate-data / events / chouette jobs / line statistics,
+│                    NeTEx validation reports)
+├── store/           configureStore + typed hooks
+├── theme/           theme factory + globalStyles
+└── utils/           getApiConfig, sort helpers, useAccessToken
 ```
 
-Optional environment variable `ENDPOINTBASE` overrides namespace for client including slash, e.g.
+## Authentication
 
-```
-ENDPOINTBASE=/admin/ninkasi/ \
-  ORGANISATIONS_BASE_URL=http://localhost:16001/services/organisations/ \
-  PROVIDERS_BASE_URL=http://localhost:16001/services/providers/ \
-  EVENTS_BASE_URL=http://localhost:10001/services/events/ \
-  TIMETABLE_ADMIN_BASE_URL=http://localhost:11002/services/timetable_admin/ \
-  MAP_ADMIN_BASE_URL=http://localhost:11002/services/map_admin/ \
-  npm start dev
-```
+OIDC via [react-oidc-context](https://github.com/authts/react-oidc-context),
+configured against Entur's Auth0 tenants per env. Access is gated on the
+`isRouteDataAdmin` role assignment (see `UserContextReducer`); users without
+the role see a `NoAccess` screen.
 
-### Authentication
+For local development, the `local` config switches `defaultAuthMethod` to
+`local` and fetches a token from a mock OAuth2 server at
+`http://localhost:21999/default/token`. The `auth/` module handles both paths
+transparently.
 
-We're using OIDC, not connected to any specific provider
+## Deployment
+
+Two GitHub Actions workflows in `.github/workflows/`:
+
+- **`firebase-hosting-merge.yml`** — runs on every push to `master`. Builds
+  once, then deploys to dev → staging → prod sequentially. Each deploy step
+  copies `build/config.{env}.json` over `build/config.json` before uploading.
+- **`firebase-hosting-pull-request.yml`** — builds and posts a preview URL on
+  every PR, using the dev config.
+
+`firebase.json` carves out a no-store cache rule for `/config.json` (above the
+catch-all `*.json` 1-year rule) so runtime config changes propagate
+immediately.
+
+## Related repos
+
+- [enki](https://github.com/entur/enki), [nirgali](https://github.com/entur/nirgali) — modernized sister admin apps, reference for the
+  MUI + RTK patterns used here.
+- [inanna](https://github.com/entur/inanna) — modernization template repo.
+- [netex-explorer](https://github.com/entur/netex-explorer) — reference for
+  the theme + runtime-config / env-badge pattern.

--- a/public/config.dev.json
+++ b/public/config.dev.json
@@ -1,5 +1,4 @@
 {
-  "appEnv": "dev",
   "envLabel": "dev",
   "envLabelColor": "#1a8e60",
   "providersBaseUrl": "https://api.dev.entur.io/timetable-admin/v1/providers/",

--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,4 @@
 {
-  "appEnv": "local",
   "envLabel": "local",
   "envLabelColor": "#067eb2",
   "providersBaseUrl": "http://localhost:21089/services/providers/",

--- a/public/config.prod.json
+++ b/public/config.prod.json
@@ -1,5 +1,4 @@
 {
-  "appEnv": "prod",
   "providersBaseUrl": "https://api.entur.io/timetable-admin/v1/providers/",
   "organisationsBaseUrl": "https://api.entur.io/timetable-admin/v1/organisations/",
   "eventsBaseUrl": "https://api.entur.io/timetable-admin/v1/events/",

--- a/public/config.staging.json
+++ b/public/config.staging.json
@@ -1,5 +1,4 @@
 {
-  "appEnv": "test",
   "envLabel": "staging",
   "envLabelColor": "#e9b10c",
   "providersBaseUrl": "https://api.staging.entur.io/timetable-admin/v1/providers/",

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -1,8 +1,6 @@
 import React, { useContext } from 'react';
 
 export interface Config {
-  appEnv?: string;
-
   /**
    * Optional environment chip next to the wordmark (e.g. "dev", "staging").
    * Absent → no chip rendered. Prod typically omits this so the badge hides.


### PR DESCRIPTION
The README was still describing convict.js, REACT_APP env vars, and Node 18 — none of which apply after the PR-A→PR-D modernization and the recent bootstrap-config switch in #587.

## What's in here

- **Stack** — current versions of React/Vite/TS/MUI/RTK/Router; mentions the inlined MFs.
- **Run locally** — Node 24, dev server on :9000, how to point at the dev APIs from local.
- **Configuration** — explains the runtime-config pattern: one \`config.json\` fetched at boot, four env-specific JSONs in \`public/\`, deploy injects the right one. Table of which file is served when, plus a breakdown of the fields each config carries.
- **Scripts** — actual npm scripts in package.json.
- **Project layout** — one-line description per directory in \`src/\`.
- **Authentication** — OIDC + Auth0, \`isRouteDataAdmin\` gate, local mock OAuth2 path.
- **Deployment** — the two GHA workflows and the \`firebase.json\` no-store carve-out for \`/config.json\`.

## Test plan
- [ ] Render the markdown on GitHub and skim it