### PR TITLE
Fix Graph/Clean dropdowns: use Menu instead of Popover

### DIFF
--- a/src/screens/providers/components/AdministrativeActions.tsx
+++ b/src/screens/providers/components/AdministrativeActions.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react';
 import type { MouseEvent } from 'react';
 import { useAppDispatch } from 'store/hooks';
 import { useAccessToken } from '@/utils/useAccessToken';
-import { Box, MenuItem, Popover } from '@mui/material';
+import { Box, Menu, MenuItem } from '@mui/material';
 import { Warning, ArrowDropDown, KeyboardArrowRight } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import ConfirmDialog from '../../../modals/ConfirmDialog';
@@ -205,7 +205,7 @@ const AdministrativeActions = () => {
         >
           Graph
         </Button>
-        <Popover
+        <Menu
           open={graphPopoverOpen}
           anchorEl={anchorEl}
           anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
@@ -240,7 +240,7 @@ const AdministrativeActions = () => {
           >
             Build Candidate Street Graph
           </MenuItem>
-        </Popover>
+        </Menu>
         <Button
           variant="text"
           size="small"
@@ -281,7 +281,7 @@ const AdministrativeActions = () => {
           Cancel all jobs
         </Button>
       </Box>
-      <Popover
+      <Menu
         open={cleanPopoverOpen}
         anchorEl={anchorEl}
         anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
@@ -329,7 +329,7 @@ const AdministrativeActions = () => {
         >
           Clean Level 2
         </MenuItem>
-      </Popover>
+      </Menu>
       <ConfirmDialog
         open={confirmDialogOpen}
         handleSubmit={confirmAction}


### PR DESCRIPTION
## Bug

Clicking the **Graph** (or **Clean**) toolbar button in \`AdministrativeActions\` blanks the page with:

\`\`\`
MUI: MenuListContext is missing. MenuItems must be placed within Menu or MenuList.
\`\`\`

## Cause

MUI 9 made \`MenuItem\` require a \`MenuListContext\`. The two dropdowns rendered \`MenuItem\`s as direct children of raw \`<Popover>\`, which doesn't supply that context.

## Fix

Swap both \`<Popover>\` wrappers for \`<Menu>\` — Menu is built on Popover and supplies the context. API otherwise identical (anchorEl / open / onClose / anchorOrigin / transformOrigin).

\`LatestOTPGraphVersions\`' Popover stays as Popover — it wraps a \`<Box>\`, not MenuItems.

## Test plan
- [ ] Click **Graph** in the top admin bar → menu opens with 4 build options
- [ ] Click **Clean** in the top admin bar → menu opens with file-filter / event-history / stop-places / clean-all options
- [ ] Click outside → menu closes
- [ ] Click a menu item → action fires + menu closes